### PR TITLE
fix YouTube embeds for shorts

### DIFF
--- a/ui/src/components/PostCard/embed.js
+++ b/ui/src/components/PostCard/embed.js
@@ -36,8 +36,14 @@ const YoutubeEmbed = ({ url }) => {
   let videoId = '';
   const u = new URL(url);
   if (['youtube.com', 'www.youtube.com', 'm.youtube.com'].includes(u.hostname)) {
-    const params = new URLSearchParams(u.search);
-    videoId = params.get('v');
+    // fix embeds for shorts, which seem to only appear on youtube.com and not youtu.be
+    let pathArray = u.pathname.split('/');
+    if (pathArray.includes('shorts')) {
+      videoId = pathArray[2];
+    } else {
+      const params = new URLSearchParams(u.search);
+      videoId = params.get('v');
+    }
   } else if (u.hostname === 'youtu.be' || u.hostname === 'www.youtu.be') {
     videoId = u.pathname;
   }


### PR DESCRIPTION
YouTube shorts do not currently embed properly ([example here](https://discuit.net/Cats/post/JIBgwHuY)).

This patch should extract the video ID from the shorts URL properly for embedding in Discuit.