### PR TITLE
Add feature Lists (bookmarks) (#77)

### DIFF
--- a/core/comment.go
+++ b/core/comment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -14,11 +15,47 @@ import (
 	"github.com/discuitnet/discuit/internal/utils"
 )
 
-// When referencing target_type column of posts_comments table.
+// ContentType distinguishes between different types of user generated content
+// (like posts and comments). It's integer values is used when interacting with
+// the DB. With the use of the MarshalText and UnmarshalText functions, this
+// type, when used as a field in a struct, is JSON marshaled and unmarshaled as
+// a string.
+type ContentType int
+
 const (
-	postsCommentsTypePosts    = 0
-	postsCommentsTypeComments = 1
+	ContentTypePost = ContentType(iota)
+	ContentTypeComment
 )
+
+func (t ContentType) String() string {
+	b, err := t.MarshalText()
+	if err != nil {
+		return "[error]"
+	}
+	return string(b)
+}
+
+func (t ContentType) MarshalText() ([]byte, error) {
+	switch t {
+	case ContentTypePost:
+		return []byte("post"), nil
+	case ContentTypeComment:
+		return []byte("comment"), nil
+	}
+	return nil, errors.New("unsupported content type")
+}
+
+func (t *ContentType) UnmarshalText(data []byte) error {
+	switch string(data) {
+	case "post":
+		*t = ContentTypePost
+	case "comment":
+		*t = ContentTypeComment
+	default:
+		return errors.New("unsupported content type")
+	}
+	return nil
+}
 
 // Comment is a comment of a post.
 type Comment struct {
@@ -131,6 +168,19 @@ func GetComment(ctx context.Context, db *sql.DB, id uid.ID, viewer *uid.ID) (*Co
 		return nil, errCommentNotFound
 	}
 	return comments[0], err
+}
+
+func GetCommentsByIDs(ctx context.Context, db *sql.DB, viewer *uid.ID, ids ...uid.ID) ([]*Comment, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	where := fmt.Sprintf("WHERE comments.id IN %s", msql.InClauseQuestionMarks(len(ids)))
+	args := make([]any, len(ids))
+	for i := range ids {
+		args[i] = ids[i]
+	}
+	return getComments(ctx, db, viewer, where, args...)
 }
 
 func scanComments(ctx context.Context, db *sql.DB, rows *sql.Rows, viewer *uid.ID) ([]*Comment, error) {
@@ -354,7 +404,7 @@ func addComment(ctx context.Context, db *sql.DB, post *Post, author *User, paren
 		}
 
 		// For the user profile.
-		if _, err := tx.ExecContext(ctx, "INSERT INTO posts_comments (target_id, user_id, target_type) VALUES (?, ?, ?)", id, author.ID, postsCommentsTypeComments); err != nil {
+		if _, err := tx.ExecContext(ctx, "INSERT INTO posts_comments (target_id, user_id, target_type) VALUES (?, ?, ?)", id, author.ID, ContentTypeComment); err != nil {
 			return err
 		}
 

--- a/core/feed.go
+++ b/core/feed.go
@@ -661,7 +661,7 @@ type UserFeedItem struct {
 	// Item is either a post or a comment.
 	Item any `json:"item"`
 	// Type is Item's type.
-	Type string `json:"type"`
+	Type ContentType `json:"type"`
 }
 
 // UserFeedResultSet holds the user page's feed's items.
@@ -680,9 +680,9 @@ func GetUserFeed(ctx context.Context, db *sql.DB, viewer *uid.ID, userID uid.ID,
 
 	if filter != "" {
 		query += "AND target_type = ? "
-		t := postsCommentsTypePosts
+		t := ContentTypePost
 		if filter == "comments" {
-			t = postsCommentsTypeComments
+			t = ContentTypeComment
 		}
 		args = append(args, t)
 	}
@@ -709,10 +709,10 @@ func GetUserFeed(ctx context.Context, db *sql.DB, viewer *uid.ID, userID uid.ID,
 	}
 
 	var ids []uid.ID
-	var types []int
+	var types []ContentType
 	for rows.Next() {
 		id := uid.ID{}
-		var t int
+		var t ContentType
 		if err = rows.Scan(&id, &t); err != nil {
 			return nil, err
 		}
@@ -723,36 +723,50 @@ func GetUserFeed(ctx context.Context, db *sql.DB, viewer *uid.ID, userID uid.ID,
 		return nil, err
 	}
 	if len(ids) == 0 {
-		return &UserFeedResultSet{}, nil
+		return &UserFeedResultSet{Items: []UserFeedItem{}}, nil
 	}
 
 	max := len(ids) - 1
 	if len(ids) < limit+1 {
 		max = len(ids)
 	}
-	set := &UserFeedResultSet{}
+	var (
+		set             = &UserFeedResultSet{Items: make([]UserFeedItem, max)}
+		postIDs         = make([]uid.ID, 0, max)
+		commentIDs      = make([]uid.ID, 0, max)
+		postItemsMap    = make(map[uid.ID]*UserFeedItem, max)
+		commentItemsMap = make(map[uid.ID]*UserFeedItem, max)
+	)
 	for i := 0; i < max; i++ {
-		// TODO: Optimize fetching posts and comments.
-		item := UserFeedItem{}
-		if types[i] == postsCommentsTypePosts {
-			item.Type = "post"
-			if item.Item, err = GetPost(ctx, db, &ids[i], "", viewer, true); err != nil {
-				return nil, err
-			}
-		} else if types[i] == postsCommentsTypeComments {
-			item.Type = "comment"
-			var c *Comment
-			if c, err = GetComment(ctx, db, ids[i], viewer); err != nil {
-				return nil, err
-			}
-			if p, err := GetPost(ctx, db, &c.PostID, "", nil, true); err == nil {
-				c.PostTitle = p.Title
-			} else {
-				return nil, err
-			}
-			item.Item = c
+		item := &set.Items[i]
+		item.Type = types[i]
+		if types[i] == ContentTypePost {
+			postIDs = append(postIDs, ids[i])
+			postItemsMap[ids[i]] = item
+		} else if types[i] == ContentTypeComment {
+			commentIDs = append(commentIDs, ids[i])
+			commentItemsMap[ids[i]] = item
 		}
-		set.Items = append(set.Items, item)
+	}
+
+	if len(postIDs) > 0 {
+		posts, err := GetPostsByIDs(ctx, db, viewer, true, postIDs...)
+		if err != nil {
+			return nil, err
+		}
+		for _, post := range posts {
+			postItemsMap[post.ID].Item = post
+		}
+	}
+
+	if len(commentIDs) > 0 {
+		comments, err := GetCommentsByIDs(ctx, db, viewer, commentIDs...)
+		if err != nil {
+			return nil, err
+		}
+		for _, comment := range comments {
+			commentItemsMap[comment.ID].Item = comment
+		}
 	}
 
 	if len(ids) == limit+1 {

--- a/core/list.go
+++ b/core/list.go
@@ -1,0 +1,567 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/discuitnet/discuit/internal/httperr"
+	msql "github.com/discuitnet/discuit/internal/sql"
+	"github.com/discuitnet/discuit/internal/uid"
+	"github.com/discuitnet/discuit/internal/utils"
+)
+
+type ListItemsSort int
+
+const (
+	ListItemsSortByAddedDsc = ListItemsSort(iota)
+	ListItemsSortByAddedAsc
+	ListItemsSortByCreatedDesc
+	ListItemsSortByCreatedAsc
+
+	ListOrderingDefault = ListItemsSortByAddedDsc
+)
+
+func (o ListItemsSort) String() string {
+	switch o {
+	case ListItemsSortByAddedDsc:
+		return "addedDsc"
+	case ListItemsSortByAddedAsc:
+		return "addedAsc"
+	case ListItemsSortByCreatedDesc:
+		return "createdDsc"
+	case ListItemsSortByCreatedAsc:
+		return "createdAsc"
+	}
+	return "" // Unsupported list sort.
+}
+
+// MarshalText implements the text.Marshaler interface. It returns an
+// httperr.Error (bad request) on error.
+func (o ListItemsSort) MarshalText() ([]byte, error) {
+	text := o.String()
+	if text == "" {
+		return nil, httperr.NewBadRequest("invalid-list-sort", "Invalid list sort.")
+	}
+	return []byte(text), nil
+}
+
+// UnmarshalText implements the text.Unmarshaler interface. It returns an
+// httperr.Error (bad request) on error.
+func (o *ListItemsSort) UnmarshalText(data []byte) error {
+	switch string(data) {
+	case "addedDsc":
+		*o = ListItemsSortByAddedDsc
+	case "addedAsc":
+		*o = ListItemsSortByAddedAsc
+	case "createdDsc":
+		*o = ListItemsSortByCreatedDesc
+	case "createdAsc":
+		*o = ListItemsSortByCreatedAsc
+	}
+	return httperr.NewBadRequest("invalid-list-sort", "Invalid list sort.")
+}
+
+type List struct {
+	ID            int             `json:"id"`
+	UserID        uid.ID          `json:"userId"`
+	Username      string          `json:"username"`
+	Name          string          `json:"name"`
+	DisplayName   string          `json:"displayName"`
+	Description   msql.NullString `json:"description"`
+	Public        bool            `json:"public"`
+	NumItmes      int             `json:"numItems"`
+	Sort          ListItemsSort   `json:"sort"` // current sort
+	CreatedAt     time.Time       `json:"createdAt"`
+	LastUpdatedAt time.Time       `json:"lastUpdatedAt"`
+}
+
+func getLists(ctx context.Context, db *sql.DB, where string, args ...any) ([]*List, error) {
+	query := msql.BuildSelectQuery("lists", []string{
+		"lists.id",
+		"lists.user_id",
+		"users.username",
+		"lists.name",
+		"lists.display_name",
+		"lists.description",
+		"lists.public",
+		"lists.num_items",
+		"lists.ordering",
+		"lists.created_at",
+		"lists.last_updated_at",
+	}, []string{
+		"INNER JOIN users on lists.user_id = users.id",
+	}, where)
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	lists := []*List{}
+	for rows.Next() {
+		list := &List{}
+		err = rows.Scan(
+			&list.ID,
+			&list.UserID,
+			&list.Username,
+			&list.Name,
+			&list.DisplayName,
+			&list.Description,
+			&list.Public,
+			&list.NumItmes,
+			&list.Sort,
+			&list.CreatedAt,
+			&list.LastUpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		lists = append(lists, list)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return lists, nil
+}
+
+func GetList(ctx context.Context, db *sql.DB, id int) (*List, error) {
+	lists, err := getLists(ctx, db, "WHERE lists.id = ?", id)
+	if err != nil {
+		return nil, err
+	}
+	if len(lists) == 0 {
+		return nil, httperr.NewNotFound("list-not-found", "List not found.")
+	}
+	return lists[0], nil
+}
+
+func GetListByName(ctx context.Context, db *sql.DB, user uid.ID, name string) (*List, error) {
+	lists, err := getLists(ctx, db, "WHERE user_id = ? AND lists.name = ?", user, name)
+	if err != nil {
+		return nil, err
+	}
+	if len(lists) == 0 {
+		return nil, httperr.NewNotFound("list-not-found", "List not found.")
+	}
+	return lists[0], nil
+}
+
+// GetUsersLists returns all the lists of user. The argument sort has to be
+// either empty or one of be one of: lexical, last_updated. And filter has to be
+// either empty or one of: all, public, private.
+func GetUsersLists(ctx context.Context, db *sql.DB, user uid.ID, sort, filter string) ([]*List, error) {
+	if sort == "" {
+		sort = "lastAdded"
+	}
+	if filter == "" {
+		filter = "all"
+	}
+	if !(sort == "name" || sort == "lastAdded") {
+		return nil, httperr.NewBadRequest("invalid-lists-sort", "Invalid lists sort.")
+	}
+	if !(filter == "all" || filter == "public" || filter == "private") {
+		return nil, httperr.NewBadRequest("invalid-lists-filter", "Invalid lists filter.")
+	}
+
+	where := "WHERE user_id = ? "
+	if filter == "public" {
+		where += "AND public = true "
+	} else if filter == "private" {
+		where += "AND public = false "
+	}
+	if sort == "name" {
+		where += "ORDER BY name ASC"
+	} else if sort == "lastAdded" {
+		where += "ORDER BY last_updated_at DESC"
+	}
+
+	return getLists(ctx, db, where, user)
+}
+
+// listnameValid always returns an httperr.Error.
+func listnameValid(name string) error {
+	if err := IsUsernameValid(name); err != nil {
+		return httperr.NewBadRequest("invalid-list-name", fmt.Sprintf("list name %v", err))
+	}
+	return nil
+}
+
+func truncateListDisplayName(s string) string {
+	return utils.TruncateUnicodeString(s, 50)
+}
+
+func CreateList(ctx context.Context, db *sql.DB, user uid.ID, name, displayName string, description msql.NullString, public bool) error {
+	if description.String == "" {
+		description.Valid = false
+	}
+
+	if err := listnameValid(name); err != nil {
+		return err
+	}
+
+	displayName = truncateListDisplayName(displayName)
+
+	description.String = utils.TruncateUnicodeString(description.String, maxUserProfileAboutLength)
+	query, args := msql.BuildInsertQuery("lists", []msql.ColumnValue{
+		{Name: "user_id", Value: user},
+		{Name: "name", Value: name},
+		{Name: "display_name", Value: displayName},
+		{Name: "description", Value: description},
+		{Name: "public", Value: public},
+		{Name: "ordering", Value: ListOrderingDefault},
+	})
+	_, err := db.ExecContext(ctx, query, args...)
+	if err != nil && msql.IsErrDuplicateErr(err) {
+		return &httperr.Error{
+			HTTPStatus: http.StatusConflict,
+			Code:       "duplicate-list",
+			Message:    "A list with that name already exists.",
+		}
+	}
+	return err
+}
+
+// Update updates the list's updatable fields.
+func (l *List) Update(ctx context.Context, db *sql.DB) error {
+	// Check errors:
+	if err := listnameValid(l.Name); err != nil {
+		return err
+	}
+
+	// Truncate:
+	l.Description.String = utils.TruncateUnicodeString(l.Description.String, maxUserProfileAboutLength)
+	l.DisplayName = truncateListDisplayName(l.DisplayName)
+
+	_, err := db.ExecContext(ctx, `
+		UPDATE lists SET 
+			name = ?, 
+			display_name = ?, 
+			description = ?,
+			public = ?, 
+			ordering = ? 
+		WHERE lists.id = ?`,
+		l.Name,
+		l.DisplayName,
+		l.Description,
+		l.Public,
+		l.Sort,
+		l.ID)
+	return err
+}
+
+// UnmarshalUpdatableFieldsJSON extracts the updatable values of the list from
+// the encoded JSON string.
+func (l *List) UnmarshalUpdatableFieldsJSON(data []byte) error {
+	temp := *l // shallow copy
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return err
+	}
+	l.Name = temp.Name
+	l.DisplayName = temp.DisplayName
+	l.Description = temp.Description
+	if l.Description.String == "" {
+		l.Description.Valid = false
+	}
+	l.Public = temp.Public
+	l.Sort = temp.Sort
+	return nil
+}
+
+func (l *List) Delete(ctx context.Context, db *sql.DB) error {
+	// The list items will be automaticaly deleted because ON DELETE CASCADE is
+	// set on the foreign key on the list_items table.
+	_, err := db.ExecContext(ctx, "DELETE FROM lists WHERE id = ?", l.ID)
+	return err
+}
+
+func (l *List) AddItem(ctx context.Context, db *sql.DB, targetType ContentType, targetID uid.ID) error {
+	errDup := errors.New("duplicate")
+	err := msql.Transact(ctx, db, func(tx *sql.Tx) error {
+		query, args := msql.BuildInsertQuery("list_items", []msql.ColumnValue{
+			{Name: "list_id", Value: l.ID},
+			{Name: "target_type", Value: targetType},
+			{Name: "target_id", Value: targetID},
+		})
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			if msql.IsErrDuplicateErr(err) {
+				return errDup
+			}
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, "UPDATE lists SET num_items = num_items + 1, last_updated_at = now() WHERE id = ?", l.ID); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err == errDup {
+		return nil
+	}
+	return err
+}
+
+func (l *List) DeleteItem(ctx context.Context, db *sql.DB, targetType ContentType, targetID uid.ID) error {
+	err := msql.Transact(ctx, db, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "DELETE FROM list_items WHERE list_id = ? AND target_id = ? AND target_type = ?", l.ID, targetID, targetType)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, "UPDATE lists SET num_items = num_items - 1 WHERE id = ?", l.ID); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+func (l *List) DeleteAllItems(ctx context.Context, db *sql.DB) error {
+	err := msql.Transact(ctx, db, func(tx *sql.Tx) error {
+		_, err := db.ExecContext(ctx, "DELETE FROM list_items WHERE list_id = ?", l.ID)
+		if err != nil {
+			return err
+		}
+		if _, err := db.Exec("UPDATE lists SET num_items = 0 WHERE id = ?", l.ID); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+type ListItem struct {
+	ID         int         `json:"id"`
+	ListID     int         `json:"listId"`
+	TargetType ContentType `json:"targetType"`
+	TargetID   uid.ID      `json:"targetId"`
+	CreatedAt  time.Time   `json:"createdAt"` // When the list item was created, not the target item.
+
+	TargetItem any `json:"targetItem"` // Either a Post or a Comment.
+}
+
+func GetListItem(ctx context.Context, db *sql.DB, listID, itemID int) (*ListItem, error) {
+	query := buildSelectListItemsQuery("WHERE id = ? AND list_id = ?")
+	args := []any{itemID, listID}
+
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := scanListItems(rows, listID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(items) == 0 {
+		return nil, fmt.Errorf("list item not found for listID %d and itemID %d", listID, itemID)
+	}
+
+	return items[0], nil
+}
+
+// The next string should contain either a timestamp or a marshaled uid.ID; if
+// not, the function will return an error. It's safe for next to be nil.
+func GetListItems(ctx context.Context, db *sql.DB, listID, limit int, sort ListItemsSort, next *string, viewer *uid.ID) (*ListItemsResultSet, error) {
+	query := buildSelectListItemsQuery("WHERE list_id = ?")
+	args := []any{listID}
+
+	// Parse the pagination cursor, if present.
+	if next != nil {
+		if sort == ListItemsSortByAddedAsc || sort == ListItemsSortByAddedDsc {
+			// next should be a time.Time value.
+			i, err := strconv.ParseInt(*next, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse next (GetListItems, time): %w", err)
+			}
+			nextTime := time.Unix(i, 0)
+			if sort == ListItemsSortByAddedAsc {
+				query += " AND created_at >= ?"
+			} else {
+				// order is ListItemsSortByAddedDsc.
+				query += " AND created_at <= ?"
+			}
+			args = append(args, nextTime)
+		} else {
+			// next should be a uid.ID.
+			nextID, err := uid.FromString(*next)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse next (GetListItems, uid.ID): %w", err)
+			}
+			if sort == ListItemsSortByCreatedAsc {
+				query += " AND target_id >= ?"
+			} else {
+				// order is ListItemsSortByCreatedDsc
+				query += " AND target_id <= ?"
+			}
+			args = append(args, nextID)
+		}
+	}
+
+	orderBy := ""
+	switch sort {
+	case ListItemsSortByAddedAsc:
+		orderBy = "created_at ASC"
+	case ListItemsSortByAddedDsc:
+		orderBy = "created_at DESC"
+	case ListItemsSortByCreatedAsc:
+		orderBy = "target_id ASC"
+	case ListItemsSortByCreatedDesc:
+		orderBy = "target_id ASC"
+	}
+	query += " ORDER BY " + orderBy
+
+	if limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", limit+1) // +1 for an extra item for the next cursor.
+	}
+
+	// Fetch the rows.
+	rows, err := db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := scanListItems(rows, listID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return the result set.
+	set := &ListItemsResultSet{}
+	if len(items) > limit {
+		lastItem := items[len(items)-1]
+		set.Next = new(string)
+		if sort == ListItemsSortByAddedAsc || sort == ListItemsSortByAddedDsc {
+			// Sort by added at.
+			*set.Next = strconv.FormatInt(lastItem.CreatedAt.Unix(), 10)
+		} else {
+			// Sort by target created at.
+			*set.Next = lastItem.TargetID.String()
+		}
+		set.Items = items[:len(items)-1]
+	} else {
+		set.Items = items
+	}
+
+	// Fetch the posts and comments.
+	var (
+		postIDs         = make([]uid.ID, 0, len(set.Items))
+		postItemsMap    = make(map[uid.ID]*ListItem, len(set.Items))
+		commentIDs      = make([]uid.ID, 0, len(set.Items))
+		commentItemsMap = make(map[uid.ID]*ListItem, len(set.Items))
+	)
+	for _, item := range set.Items {
+		if item.TargetType == ContentTypePost {
+			postIDs = append(postIDs, item.TargetID)
+			postItemsMap[item.TargetID] = item
+		} else if item.TargetType == ContentTypeComment {
+			commentIDs = append(commentIDs, item.TargetID)
+			commentItemsMap[item.TargetID] = item
+		}
+	}
+
+	posts, err := GetPostsByIDs(ctx, db, viewer, true, postIDs...)
+	if err != nil {
+		return nil, err
+	}
+	for _, post := range posts {
+		postItemsMap[post.ID].TargetItem = post
+	}
+
+	comments, err := GetCommentsByIDs(ctx, db, viewer, commentIDs...)
+	if err != nil {
+		return nil, err
+	}
+	for _, comment := range comments {
+		commentItemsMap[comment.ID].TargetItem = comment
+	}
+
+	return set, nil
+}
+
+func (li *ListItem) Delete(ctx context.Context, db *sql.DB) error {
+	err := msql.Transact(ctx, db, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, "UPDATE lists SET num_items = num_items - 1 WHERE id = ?", li.ListID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, "DELETE FROM list_items WHERE id = ?", li.ID); err != nil {
+			return err
+		}
+		return nil
+	})
+	return err
+}
+
+func buildSelectListItemsQuery(where string) string {
+	return "SELECT id, target_type, target_id, created_at FROM list_items " + where
+}
+
+func scanListItems(rows *sql.Rows, listID int) ([]*ListItem, error) {
+	defer rows.Close()
+
+	items := []*ListItem{}
+	for rows.Next() {
+		item := &ListItem{ListID: listID}
+		err := rows.Scan(
+			&item.ID,
+			&item.TargetType,
+			&item.TargetID,
+			&item.CreatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}
+
+type ListItemsResultSet struct {
+	Items []*ListItem `json:"items"`
+	Next  *string     `json:"next"` // either a timestamp or a uid.ID.
+}
+
+// ListsItemIsSavedTo returns the ids of the lists the post or comment target is
+// saved in.
+func ListsItemIsSavedTo(ctx context.Context, db *sql.DB, user uid.ID, targetID uid.ID, targetType ContentType) ([]int, error) {
+	rows, err := db.QueryContext(ctx, `
+		select 
+			lists.id 
+		from list_items 
+		inner join lists on lists.id = list_items.list_id 
+		where 
+			list_items.target_id = ? 
+			and list_items.target_type = ?`,
+		targetID, targetType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	ids := []int{} // So, it's JSON marshaled as an array.
+	for rows.Next() {
+		var id int
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return ids, nil
+}

--- a/core/user.go
+++ b/core/user.go
@@ -460,6 +460,12 @@ func RegisterUser(ctx context.Context, db *sql.DB, username, email, password str
 		log.Println("Failed to add user to default communities: ", err)
 		// Continue on failure.
 	}
+
+	if err := CreateList(ctx, db, id, "bookmarks", "Bookmarks", msql.NullString{}, false); err != nil {
+		log.Println("Failed to create the default community of user: ", username)
+		// Continue on failure.
+	}
+
 	return GetUser(ctx, db, id, nil)
 }
 
@@ -665,6 +671,11 @@ func (u *User) Delete(ctx context.Context) error {
 
 		// Delete the user's web push subscriptions.
 		if _, err := tx.ExecContext(ctx, "DELETE FROM web_push_subscriptions WHERE user_id = ?", u.ID); err != nil {
+			return err
+		}
+
+		// Delete the user's lists.
+		if _, err := tx.ExecContext(ctx, "DELETE FROM lists WHERE user_id = ?", u.ID); err != nil {
 			return err
 		}
 

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -260,7 +260,7 @@ func (i *NullBool) Scan(src interface{}) error {
 	case []byte:
 		i.Bool = string(v) != "0"
 	default:
-		return errors.New("Scanning NullBool, unspecified src type")
+		return errors.New("scanning NullBool, unspecified src type")
 	}
 
 	return nil
@@ -381,7 +381,7 @@ func Transact(ctx context.Context, db *sql.DB, f func(tx *sql.Tx) error) error {
 	}
 
 	if err := f(tx); err != nil {
-		if rErr := tx.Rollback(); err != nil {
+		if rErr := tx.Rollback(); rErr != nil {
 			return fmt.Errorf("%w (rollback error: %w)", err, rErr)
 		}
 		return err

--- a/migrations/0043_add_lists.down.sql
+++ b/migrations/0043_add_lists.down.sql
@@ -1,0 +1,2 @@
+drop table if exists list_items;
+drop table if exists lists;

--- a/migrations/0043_add_lists.up.sql
+++ b/migrations/0043_add_lists.up.sql
@@ -1,0 +1,39 @@
+create table if not exists lists (
+	id bigint unsigned not null auto_increment,
+	user_id binary (12) not null,
+    name varchar (128) not null, /* A unique identifier for each list (per user). */
+    display_name varchar (128) not null,
+    public bool not null default false,
+    description text,
+    num_items int not null default 0,
+    ordering tinyint not null default 0,
+	created_at datetime not null default current_timestamp(),
+	last_updated_at datetime not null default current_timestamp(),
+
+    primary key (id),
+    unique (user_id, name),
+    index (user_id, created_at)
+) AUTO_INCREMENT = 100000;
+
+create table if not exists list_items (
+	id bigint unsigned not null auto_increment,
+	list_id bigint unsigned not null,
+	target_type tinyint not null,
+	target_id binary (12) not null, /* This column should be time ordered, since it represents uid.ID values. */
+	created_at datetime not null default current_timestamp(), /* When the row's created, not the target. */
+
+    primary key (id),
+    unique (list_id, target_type, target_id),
+    index (list_id, target_id), /* Ordered by target created at time. */
+    index (list_id, created_at),
+    foreign key (list_id) references lists (id) ON DELETE CASCADE
+);
+
+/* 
+ * Create a favorites list for each user.
+ * 
+ * NOTE: Whenever changing the following line, make sure to change the
+ * create-new-user function in Go as well.
+ *
+ */
+insert into lists (user_id, name, display_name) select users.id, "bookmarks", "Bookmarks" from users;

--- a/server/admin.go
+++ b/server/admin.go
@@ -69,7 +69,7 @@ func (s *Server) adminActions(w *responseWriter, r *request) error {
 			return err
 		}
 	default:
-		return httperr.NewBadRequest("unsupported_action", "Unsupported admin action.")
+		return httperr.NewBadRequest("invalid_action", "Unsupported admin action.")
 	}
 
 	return w.writeString(`{"success:":true}`)

--- a/server/comment.go
+++ b/server/comment.go
@@ -16,7 +16,7 @@ func (s *Server) getComments(w *responseWriter, r *request) error {
 		return err
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 
 	// Reply comments.
 	parentIDText := query.Get("parentId")
@@ -107,7 +107,7 @@ func (s *Server) addComment(w *responseWriter, r *request) error {
 	}
 
 	var as core.UserGroup = core.UserGroupNormal
-	if _as := r.urlQuery().Get("userGroup"); _as != "" {
+	if _as := r.urlQueryParams().Get("userGroup"); _as != "" {
 		if err = as.UnmarshalText([]byte(_as)); err != nil {
 			return err
 		}
@@ -148,7 +148,7 @@ func (s *Server) updateComment(w *responseWriter, r *request) error {
 		return err
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	action := query.Get("action")
 	if action == "" {
 		var tcom core.Comment
@@ -171,7 +171,7 @@ func (s *Server) updateComment(w *responseWriter, r *request) error {
 				return err
 			}
 		default:
-			return httperr.NewBadRequest("unsupported_action", "Unsupported action.")
+			return httperr.NewBadRequest("invalid_action", "Unsupported action.")
 		}
 	}
 
@@ -197,7 +197,7 @@ func (s *Server) deleteComment(w *responseWriter, r *request) error {
 		return err
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	deleteAs := core.UserGroupNormal
 	if _deleteAs := query.Get("deleteAs"); _deleteAs != "" {
 		if err = deleteAs.UnmarshalText([]byte(_deleteAs)); err != nil {

--- a/server/community.go
+++ b/server/community.go
@@ -57,7 +57,7 @@ func (s *Server) createCommunity(w *responseWriter, r *request) error {
 
 // /api/communities [GET] (?set=subscribed&sort=size)
 func (s *Server) getCommunities(w *responseWriter, r *request) error {
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	search := query.Get("q")
 
 	set := query.Get("set") // Either "all" or "default" or "subscribed".
@@ -123,7 +123,7 @@ func (s *Server) getCommunities(w *responseWriter, r *request) error {
 func (s *Server) getCommunity(w *responseWriter, r *request) error {
 	var (
 		communityID = r.muxVar("communityID") // Community ID or name.
-		query       = r.urlQuery()
+		query       = r.urlQueryParams()
 		comm        *core.Community
 		byName      = strings.ToLower(query.Get("byName")) == "true"
 		err         error
@@ -164,7 +164,7 @@ func (s *Server) updateCommunity(w *responseWriter, r *request) error {
 
 	var (
 		communityID = r.muxVar("communityID") // Community ID or name.
-		query       = r.urlQuery()
+		query       = r.urlQueryParams()
 		byName      = strings.ToLower(query.Get("byName")) == "true"
 		comm        *core.Community
 		err         error
@@ -541,7 +541,7 @@ func (s *Server) getCommunityReports(w *responseWriter, r *request) error {
 		return errNotAdminNorMod
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 
 	limit, err := getFeedLimit(query, s.config.PaginationLimit, s.config.PaginationLimitMax)
 	if err != nil {

--- a/server/feed.go
+++ b/server/feed.go
@@ -57,7 +57,7 @@ func (s *Server) getUsersFeed(w *responseWriter, r *request) error {
 		}
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	limit, err := getFeedLimit(query, s.config.PaginationLimit, s.config.PaginationLimitMax)
 	if err != nil {
 		return err
@@ -91,7 +91,7 @@ var errInvalidFeedFilter = httperr.NewBadRequest("invalid_filter", "Invalid feed
 
 // /api/posts [GET]
 func (s *Server) feed(w *responseWriter, r *request) error {
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	communityIDText := query.Get("communityId")
 	filter := query.Get("filter")
 	if !isFilterValid(filter) {

--- a/server/list.go
+++ b/server/list.go
@@ -1,0 +1,311 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/discuitnet/discuit/core"
+	"github.com/discuitnet/discuit/internal/httperr"
+	msql "github.com/discuitnet/discuit/internal/sql"
+	"github.com/discuitnet/discuit/internal/uid"
+)
+
+// /api/users/{username}/lists [GET, POST]
+func (s *Server) handleLists(w *responseWriter, r *request) error {
+	var (
+		username     = strings.ToLower(r.muxVar("username"))
+		user         *core.User
+		userIsViewer = false
+		err          error
+	)
+
+	user, err = core.GetUserByUsername(r.ctx, s.db, username, r.viewer)
+	if err != nil {
+		return err
+	}
+
+	if r.loggedIn {
+		if user.ID == *r.viewer {
+			userIsViewer = true
+		}
+	}
+
+	if r.req.Method == "POST" {
+		// Create a new list.
+
+		// Check permissions first.
+		if !r.loggedIn {
+			return errNotLoggedIn
+		}
+		if !userIsViewer {
+			return httperr.NewForbidden("not-your-list", "Not your list.")
+		}
+
+		form := struct {
+			Name        string          `json:"name"`
+			DisplayName string          `json:"displayName"` // Optional field, defaults to Name.
+			Description msql.NullString `json:"description"`
+			Public      bool            `json:"public"` // Optional field, defaults to false.
+		}{}
+		if err := r.unmarshalJSONBody(&form); err != nil {
+			return err
+		}
+
+		if form.Name == "" {
+			return httperr.NewBadRequest("list-name-empty", "List name cannot be empty.")
+		}
+		if form.DisplayName == "" {
+			form.DisplayName = form.Name
+		}
+
+		if err := s.rateLimit(r, "list_c_1_"+r.viewer.String(), time.Second*2, 1); err != nil {
+			return err
+		}
+
+		if err := s.rateLimit(r, "list_c_2_"+r.viewer.String(), time.Hour*24, 100); err != nil {
+			return err
+		}
+
+		if err := core.CreateList(r.ctx, s.db, *r.viewer, form.Name, form.DisplayName, form.Description, form.Public); err != nil {
+			return err
+		}
+	}
+
+	lists, err := core.GetUsersLists(r.ctx, s.db, user.ID, r.urlQueryParamsValue("sort"), r.urlQueryParamsValue("filter"))
+	if err != nil {
+		return err
+	}
+	if !userIsViewer {
+		// Viewer is requesting the lists of someone else. Only show them the
+		// public lists.
+		public := make([]*core.List, 0, len(lists))
+		for _, list := range lists {
+			if list.Public {
+				public = append(public, list)
+			}
+		}
+		lists = public
+	}
+	return w.writeJSON(lists)
+}
+
+// [GET, PUT, DELETE]
+func (s *Server) handeList(w *responseWriter, r *request, list *core.List) error {
+	if !r.loggedIn && r.req.Method != "GET" {
+		return errNotLoggedIn
+	}
+
+	if !list.Public {
+		errListNotFound := httperr.NewNotFound("list-not-found", "List not found.")
+		if !r.loggedIn {
+			return errListNotFound
+		}
+		viewer, err := core.GetUser(r.ctx, s.db, *r.viewer, r.viewer)
+		if err != nil {
+			return err
+		}
+		if viewer.ID != list.UserID {
+			return errListNotFound
+		}
+	}
+
+	if r.req.Method != "GET" {
+		if err := s.rateLimit(r, "list_e_1_"+r.viewer.String(), time.Second*1, 1); err != nil {
+			return err
+		}
+	}
+
+	switch r.req.Method {
+	case "PUT":
+		data, err := io.ReadAll(r.req.Body)
+		if err != nil {
+			return err
+		}
+		if err := list.UnmarshalUpdatableFieldsJSON(data); err != nil {
+			return err
+		}
+		if err := list.Update(r.ctx, s.db); err != nil {
+			return err
+		}
+	case "DELETE":
+		if err := list.Delete(r.ctx, s.db); err != nil {
+			return err
+		}
+	}
+
+	return w.writeJSON(list)
+}
+
+func (s *Server) withListByName(f func(*responseWriter, *request, *core.List) error) handler {
+	return handler(func(w *responseWriter, r *request) error {
+		user, err := core.GetUserByUsername(r.ctx, s.db, r.muxVar("username"), nil)
+		if err != nil {
+			return err
+		}
+
+		list, err := core.GetListByName(r.ctx, s.db, user.ID, r.muxVar("listname"))
+		if err != nil {
+			return err
+		}
+
+		return f(w, r, list)
+	})
+}
+
+func (s *Server) withListByID(f func(*responseWriter, *request, *core.List) error) handler {
+	return handler(func(w *responseWriter, r *request) error {
+		listID, err := strconv.Atoi(r.muxVar("listId"))
+		if err != nil {
+			return httperr.NewBadRequest("invalid-list-id", "Invalid list id.")
+		}
+
+		list, err := core.GetList(r.ctx, s.db, listID)
+		if err != nil {
+			return err
+		}
+
+		return f(w, r, list)
+	})
+}
+
+// [GET, POST, DELETE]
+func (s *Server) handleListItems(w *responseWriter, r *request, list *core.List) error {
+	if !r.loggedIn && r.req.Method != "GET" {
+		return errNotLoggedIn
+	}
+
+	if !list.Public {
+		errListNotFound := httperr.NewNotFound("list-not-found", "List not found.")
+		if !r.loggedIn {
+			return errListNotFound
+		}
+		viewer, err := core.GetUser(r.ctx, s.db, *r.viewer, r.viewer)
+		if err != nil {
+			return err
+		}
+		if viewer.ID != list.UserID {
+			return errListNotFound
+		}
+	}
+
+	if r.req.Method == "POST" {
+		if err := s.rateLimit(r, "l_item_c_1_"+r.viewer.String(), time.Second, 2); err != nil {
+			return err
+		}
+		if err := s.rateLimit(r, "l_item_c_2_"+r.viewer.String(), time.Hour, 1000); err != nil {
+			return err
+		}
+	}
+
+	if r.req.Method == "POST" || r.req.Method == "DELETE" {
+		form := struct {
+			TargetType core.ContentType `json:"targetType"`
+			TargetID   uid.ID           `json:"targetId"`
+		}{
+			TargetType: -1, // sentinel value
+		}
+		bytes, err := io.ReadAll(r.req.Body)
+		if err != nil {
+			return err
+		}
+		if len(bytes) > 0 {
+			if err := json.Unmarshal(bytes, &form); err != nil {
+				return httperr.NewBadRequest("", "Bad JSON body.")
+			}
+		}
+		if r.req.Method == "POST" {
+			if err := list.AddItem(r.ctx, s.db, form.TargetType, form.TargetID); err != nil {
+				return err
+			}
+		} else if r.req.Method == "DELETE" {
+			if form.TargetID.Zero() && form.TargetType == -1 {
+				if err := list.DeleteAllItems(r.ctx, s.db); err != nil {
+					return err
+				}
+			} else {
+				if err := list.DeleteItem(r.ctx, s.db, form.TargetType, form.TargetID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	var (
+		err   error
+		limit int
+		next  *string
+		sort  core.ListItemsSort = core.ListOrderingDefault
+	)
+
+	if limit, err = r.urlQueryParamsValueInt("limit", 10); err != nil {
+		return httperr.NewBadRequest("invalid-limit", "Invalid limit value.")
+	}
+	if nextString := r.urlQueryParamsValue("next"); nextString != "" {
+		next = &nextString
+	}
+	if sortString := r.urlQueryParamsValue("sort"); sortString != "" {
+		if err := sort.UnmarshalText([]byte(sortString)); err != nil {
+			return err
+		}
+	}
+
+	resultSet, err := core.GetListItems(r.ctx, s.db, list.ID, limit, sort, next, r.viewer)
+	if err != nil {
+		return err
+	}
+	return w.writeJSON(resultSet)
+}
+
+// /api/lists/{listId}/items/{itemId} [DELETE]
+func (s *Server) deleteListItem(w *responseWriter, r *request, list *core.List) error {
+	if !r.loggedIn {
+		return errNotLoggedIn
+	}
+
+	itemID, err := strconv.Atoi(r.muxVar("itemId"))
+	if err != nil {
+		return httperr.NewBadRequest("invalid-item-id", "Invalid item id.")
+	}
+
+	if list.UserID != *r.viewer { // Check permissions.
+		return httperr.NewForbidden("not-your-list", "Not your list.")
+	}
+
+	item, err := core.GetListItem(r.ctx, s.db, list.ID, itemID)
+	if err != nil {
+		return err
+	}
+
+	if err := item.Delete(r.ctx, s.db); err != nil {
+		return err
+	}
+
+	return w.writeJSON(item)
+}
+
+// /api/lists/_saved_to [GET]
+func (s *Server) getSaveToLists(w *responseWriter, r *request) error {
+	if !r.loggedIn {
+		return errNotLoggedIn
+	}
+
+	targetID, err := uid.FromString(r.urlQueryParamsValue("id"))
+	if err != nil {
+		return httperr.NewBadRequest("invalid-target-id", "Invalid target id.")
+	}
+
+	var targetType core.ContentType
+	if err := targetType.UnmarshalText([]byte(r.urlQueryParamsValue("type"))); err != nil {
+		return httperr.NewBadRequest("invalid-content-type", "Invalid content type.")
+	}
+
+	ids, err := core.ListsItemIsSavedTo(r.ctx, s.db, *r.viewer, targetID, targetType)
+	if err != nil {
+		return err
+	}
+
+	return w.writeJSON(ids)
+}

--- a/server/mutes.go
+++ b/server/mutes.go
@@ -68,7 +68,7 @@ func (s *Server) handleMutes(w *responseWriter, r *request) error {
 			return err
 		}
 	case "DELETE":
-		muteType := core.MuteType(r.urlQueryValue("type"))
+		muteType := core.MuteType(r.urlQueryParamsValue("type"))
 		if !muteType.Valid() {
 			return httperr.NewBadRequest("invalid_mute_type", "Invalid mute type.")
 		}

--- a/server/post.go
+++ b/server/post.go
@@ -99,7 +99,7 @@ func (s *Server) getPost(w *responseWriter, r *request) error {
 		return err
 	}
 
-	if fetchCommunity := r.urlQueryValue("fetchCommunity"); fetchCommunity == "" || fetchCommunity == "true" {
+	if fetchCommunity := r.urlQueryParamsValue("fetchCommunity"); fetchCommunity == "" || fetchCommunity == "true" {
 		comm, err := core.GetCommunityByID(r.ctx, s.db, post.CommunityID, r.viewer)
 		if err != nil {
 			return err
@@ -132,7 +132,7 @@ func (s *Server) updatePost(w *responseWriter, r *request) error {
 		return err
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	action := query.Get("action")
 	if action == "" {
 		// Update post.
@@ -212,7 +212,7 @@ func (s *Server) deletePost(w *responseWriter, r *request) error {
 	if err != nil {
 		return err
 	}
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 
 	var as core.UserGroup
 	if err = as.UnmarshalText([]byte(query.Get("deleteAs"))); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -114,6 +114,14 @@ func New(db *sql.DB, conf *config.Config) (*Server, error) {
 	r.Handle("/api/users/{username}/badges", s.withHandler(s.addBadge)).Methods("POST")
 	r.Handle("/api/users/{username}/badges/{badgeId}", s.withHandler(s.deleteBadge)).Methods("DELETE")
 
+	r.Handle("/api/users/{username}/lists", s.withHandler(s.handleLists)).Methods("GET", "POST")
+	r.Handle("/api/lists/_saved_to", s.withHandler(s.getSaveToLists)).Methods("GET")
+	r.Handle("/api/users/{username}/lists/{listname}", s.withHandler(s.withListByName(s.handeList))).Methods("GET", "PUT", "DELETE")
+	r.Handle("/api/lists/{listId}", s.withHandler(s.withListByID(s.handeList))).Methods("GET", "PUT", "DELETE")
+	r.Handle("/api/users/{username}/lists/{listname}/items", s.withHandler(s.withListByName(s.handleListItems))).Methods("GET", "POST", "DELETE")
+	r.Handle("/api/lists/{listId}/items", s.withHandler(s.withListByID(s.handleListItems))).Methods("GET", "POST", "DELETE")
+	r.Handle("/api/lists/{listId}/items/{itemId}", s.withHandler(s.withListByID(s.deleteListItem))).Methods("DELETE")
+
 	r.Handle("/api/mutes", s.withHandler(s.handleMutes)).Methods("GET", "POST", "DELETE")
 	r.Handle("/api/mutes/users/{mutedUserID}", s.withHandler(s.deleteUserMute)).Methods("DELETE")
 	r.Handle("/api/mutes/communities/{mutedCommunityID}", s.withHandler(s.deleteCommunityMute)).Methods("DELETE")
@@ -951,7 +959,7 @@ func (s *Server) rateLimit(r *request, bucketID string, interval time.Duration, 
 	}
 
 	if s.config.AdminApiKey != "" {
-		adminKey := r.urlQueryValue("adminKey")
+		adminKey := r.urlQueryParamsValue("adminKey")
 		if adminKey == s.config.AdminApiKey {
 			return nil // skip rate limits
 		}
@@ -999,7 +1007,7 @@ func (s *Server) getLinkInfo(w *responseWriter, r *request) error {
 		return err
 	}
 
-	url := r.urlQueryValue("url")
+	url := r.urlQueryParamsValue("url")
 	res, err := httputil.Get(url)
 	if err != nil {
 		return err

--- a/server/user.go
+++ b/server/user.go
@@ -112,6 +112,7 @@ func (s *Server) initial(w *responseWriter, r *request) error {
 	response := struct {
 		ReportReasons  []core.ReportReason `json:"reportReasons"`
 		User           *core.User          `json:"user"`
+		Lists          []*core.List        `json:"lists"`
 		Communities    []*core.Community   `json:"communities"`
 		NoUsers        int                 `json:"noUsers"`
 		BannedFrom     []uid.ID            `json:"bannedFrom"`
@@ -121,6 +122,7 @@ func (s *Server) initial(w *responseWriter, r *request) error {
 			UserMutes      []*core.Mute `json:"userMutes"`
 		} `json:"mutes"`
 	}{
+		Lists:          []*core.List{},
 		VAPIDPublicKey: s.webPushVAPIDKeys.Public,
 	}
 
@@ -149,6 +151,11 @@ func (s *Server) initial(w *responseWriter, r *request) error {
 			return err
 		} else if userMutes != nil {
 			response.Mutes.UserMutes = userMutes
+		}
+		if lists, err := core.GetUsersLists(r.ctx, s.db, *r.viewer, "", ""); err != nil {
+			return err
+		} else if lists != nil {
+			response.Lists = lists
 		}
 	}
 
@@ -179,7 +186,7 @@ func (s *Server) login(w *responseWriter, r *request) error {
 			return err
 		}
 
-		action := r.urlQueryValue("action")
+		action := r.urlQueryParamsValue("action")
 		if action != "" {
 			switch action {
 			case "logout":
@@ -303,7 +310,7 @@ func (s *Server) updateNotifications(w *responseWriter, r *request) error {
 		return err
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	switch query.Get("action") {
 	case "resetNewCount":
 		if err = user.ResetNewNotificationsCount(r.ctx); err != nil {
@@ -346,7 +353,7 @@ func (s *Server) getNotifications(w *responseWriter, r *request) error {
 	}
 	res.NewCount = user.NumNewNotifications
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	if res.Items, res.Next, err = core.GetNotifications(r.ctx, s.db, user.ID, 10, query.Get("next")); err != nil {
 		return err
 	}
@@ -373,7 +380,7 @@ func (s *Server) getNotification(w *responseWriter, r *request) error {
 		return httperr.NewForbidden("not_owner", "")
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	if r.req.Method == "PUT" {
 		action := query.Get("action")
 		switch action {
@@ -454,7 +461,7 @@ func (s *Server) updateUserSettings(w *responseWriter, r *request) error {
 		return err
 	}
 
-	query := r.urlQuery()
+	query := r.urlQueryParams()
 	switch query.Get("action") {
 	case "updateProfile":
 		if err = r.unmarshalJSONBody(&user); err != nil {
@@ -551,7 +558,7 @@ func (s *Server) deleteBadge(w *responseWriter, r *request) error {
 		return err
 	}
 
-	byType := strings.ToLower(r.urlQueryValue("byType")) == "true"
+	byType := strings.ToLower(r.urlQueryParamsValue("byType")) == "true"
 	if byType {
 		if err = user.RemoveBadgesByType(badgeID); err != nil {
 			return err

--- a/ui/src/AppUpdate.jsx
+++ b/ui/src/AppUpdate.jsx
@@ -76,7 +76,7 @@ const AppUpdate = () => {
     */
     return (
       <Modal open={modalOpen} onClose={handleClose} noOuterClickClose>
-        <div className="modal-card is-compact-mobile" style={{ minWidth: '300px' }}>
+        <div className="modal-card is-compact-mobile is-center" style={{ minWidth: '300px' }}>
           <div className="modal-card-head">
             <div className="modal-card-title">Update available!</div>
             <ButtonClose onClick={handleClose} />

--- a/ui/src/Elements.jsx
+++ b/ui/src/Elements.jsx
@@ -116,6 +116,14 @@ const Elements = () => {
           <div className="dropdown-item">Item four</div>
         </div>
       </Dropdown>
+      <Dropdown target="Dropdown with the default target">
+        <div className="dropdown-list">
+          <div className="dropdown-item">Item one</div>
+          <div className="dropdown-item">Item two</div>
+          <div className="dropdown-item">Item three</div>
+          <div className="dropdown-item">Item four</div>
+        </div>
+      </Dropdown>
       <p>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Natus facere cupiditate,
         asperiores, quam, ullam id nobis est incidunt dolores velit cum saepe quia voluptatem.

--- a/ui/src/PushNotifications.jsx
+++ b/ui/src/PushNotifications.jsx
@@ -134,7 +134,7 @@ const PushNotifications = () => {
 
   return (
     <Modal open={askModalOpen} onClose={handleAskModalClose} noOuterClickClose>
-      <div className="modal-card is-compact-mobile">
+      <div className="modal-card is-compact-mobile is-center">
         <div className="modal-card-head">
           <div className="modal-card-title">Turn on notifications</div>
           <ButtonClose onClick={handleAskModalClose} />

--- a/ui/src/components/Button.jsx
+++ b/ui/src/components/Button.jsx
@@ -55,7 +55,14 @@ export const ButtonMore = ({ vertical = false, outlined = false, className, ...p
       />
     </svg>
   ) : (
-    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      style={style}
+    >
       <path
         d="M5 10C3.9 10 3 10.9 3 12C3 13.1 3.9 14 5 14C6.1 14 7 13.1 7 12C7 10.9 6.1 10 5 10Z"
         stroke="currentColor"

--- a/ui/src/components/Dropdown.jsx
+++ b/ui/src/components/Dropdown.jsx
@@ -72,11 +72,19 @@ const Dropdown = ({
     }
   };
 
+  const renderTargetElement = () => {
+    return typeof target === 'string' ? (
+      <DropdownDefaultTarget>{target}</DropdownDefaultTarget>
+    ) : (
+      target
+    );
+  };
+
   if (isMobile) {
     return (
       <div ref={ref} className={'dropdown' + (className !== '' ? ` ${className}` : '')}>
         <div ref={targetRef} className="dropdown-target" onClick={() => setOpen(true)}>
-          {target}
+          {renderTargetElement()}
         </div>
         <Modal open={open} onClose={() => setOpen(false)} noOuterClickClose={false}>
           <div className="modal-dropdown" onClick={handleModalClick}>
@@ -104,7 +112,7 @@ const Dropdown = ({
         className="dropdown-target"
         onClick={toggleActive}
       >
-        {target}
+        {renderTargetElement()}
       </div>
       <div style={menuCls} className="dropdown-menu">
         {children}
@@ -114,7 +122,7 @@ const Dropdown = ({
 };
 
 Dropdown.propTypes = {
-  target: PropTypes.element.isRequired,
+  target: PropTypes.element,
   children: PropTypes.element.isRequired,
   className: PropTypes.string,
   aligned: PropTypes.oneOf(['left', 'right', 'center', 'none']),
@@ -124,3 +132,27 @@ Dropdown.propTypes = {
 };
 
 export default Dropdown;
+
+export const DropdownDefaultTarget = ({ children }) => {
+  return (
+    <button className="button-with-icon is-text-first">
+      <svg
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.9995 16.8006C11.2995 16.8006 10.5995 16.5306 10.0695 16.0006L3.54953 9.48062C3.25953 9.19062 3.25953 8.71062 3.54953 8.42063C3.83953 8.13063 4.31953 8.13063 4.60953 8.42063L11.1295 14.9406C11.6095 15.4206 12.3895 15.4206 12.8695 14.9406L19.3895 8.42063C19.6795 8.13063 20.1595 8.13063 20.4495 8.42063C20.7395 8.71062 20.7395 9.19062 20.4495 9.48062L13.9295 16.0006C13.3995 16.5306 12.6995 16.8006 11.9995 16.8006Z"
+          fill="currentColor"
+        />
+      </svg>
+      <span>{children}</span>
+    </button>
+  );
+};
+
+DropdownDefaultTarget.propTypes = {
+  children: PropTypes.element.isRequired,
+};

--- a/ui/src/components/Modal/ModalConfirm.jsx
+++ b/ui/src/components/Modal/ModalConfirm.jsx
@@ -21,7 +21,7 @@ const ModalConfirm = ({
 
   return (
     <Modal open={open} onClose={onClose} onKeyDown={handleKeyDown}>
-      <div className="modal-card is-compact-mobile">
+      <div className="modal-card is-compact-mobile is-center">
         <div className="modal-card-head">
           <div className="modal-card-title">{title}</div>
           <ButtonClose onClick={onClose} />

--- a/ui/src/components/PostCard/PostCardHeadingDetails.jsx
+++ b/ui/src/components/PostCard/PostCardHeadingDetails.jsx
@@ -6,9 +6,10 @@ import TimeAgo from '../TimeAgo';
 import { useIsMobile, useMuteCommunity, useMuteUser } from '../../hooks';
 import Dropdown from '../Dropdown';
 import { ButtonMore } from '../Button';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { UserLink } from '../UserProPic';
 import { userHasSupporterBadge } from '../../pages/User';
+import { saveToListModalOpened } from '../../slices/mainSlice';
 
 const PostCardHeadingDetails = ({
   post,
@@ -30,7 +31,7 @@ const PostCardHeadingDetails = ({
   const isMobile = useIsMobile();
   const isPinned = post.isPinned || post.isPinnedSite;
 
-  // const dispatch = useDispatch();
+  const dispatch = useDispatch();
   //
   // const isAuthorMuted = useSelector(selectIsUserMuted(post.userId));
   // const isCommunityMuted = useSelector(selectIsCommunityMuted(post.communityId));
@@ -101,6 +102,12 @@ const PostCardHeadingDetails = ({
                   {muteUserText}
                 </button>
               )}
+              <button
+                className="button-clear dropdown-item"
+                onClick={() => dispatch(saveToListModalOpened(post.id, 'post'))}
+              >
+                Save to list
+              </button>
             </div>
           </Dropdown>
         )}

--- a/ui/src/components/SaveToListModal.jsx
+++ b/ui/src/components/SaveToListModal.jsx
@@ -1,0 +1,203 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import Modal from './Modal';
+import { ButtonClose } from './Button';
+import Input from './Input';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  listsAdded,
+  saveToListModalClosed,
+  snackAlert,
+  snackAlertError,
+} from '../slices/mainSlice';
+import { mfetchjson } from '../helper';
+import { EditListForm } from '../pages/Lists/List';
+
+const SaveToListModal = () => {
+  const dispatch = useDispatch();
+  const { open, toSaveItemId, toSaveItemType } = useSelector((state) => state.main.saveToListModal);
+  const handleClose = () => dispatch(saveToListModalClosed());
+
+  if (open) {
+    return (
+      <TheModal
+        open={open}
+        onClose={handleClose}
+        toSaveItemId={toSaveItemId}
+        toSaveItemType={toSaveItemType}
+      />
+    );
+  }
+
+  return null;
+};
+
+const TheModal = ({ open, onClose, toSaveItemId, toSaveItemType }) => {
+  const handleClose = onClose;
+
+  const dispatch = useDispatch();
+
+  const user = useSelector((state) => state.main.user);
+  const [page, setPage] = useState('list'); // One of: list, new.
+
+  const [prevCheckedLists, setPrevCheckedLists] = useState(null); // List of list ids.
+  useEffect(() => {
+    const f = async () => {
+      try {
+        const ids = await mfetchjson(
+          `/api/lists/_saved_to?id=${toSaveItemId}&type=${toSaveItemType}`
+        );
+        setPrevCheckedLists(ids);
+      } catch (error) {
+        dispatch(snackAlertError(error));
+      }
+    };
+    f();
+  }, [toSaveItemId, toSaveItemType]);
+
+  const lists = useSelector((state) => state.main.lists.lists);
+  const [listState, setListState] = useState({});
+  const listsLoading = lists && listState && lists.length !== Object.keys(listState).length;
+  useEffect(() => {
+    if (prevCheckedLists === null) {
+      return;
+    }
+    setListState((prev) => {
+      const newState = {
+        ...prev,
+      };
+      for (const list of lists) {
+        if (!prev[list.id]) {
+          newState[list.id] = {
+            checked: Boolean(prevCheckedLists.find((v) => v === list.id)),
+            requestInProgress: false,
+          };
+        }
+      }
+      return newState;
+    });
+  }, [lists, prevCheckedLists]);
+  const setListItemState = (listId, state) => {
+    setListState((prev) => {
+      return {
+        ...prev,
+        [listId]: {
+          ...prev[listId],
+          ...state,
+        },
+      };
+    });
+  };
+  const handleItemClick = async (list, event) => {
+    const checked = event.target.checked;
+    setListItemState(list.id, {
+      checked,
+      requestInProgress: true,
+    });
+    try {
+      await mfetchjson(`/api/lists/${list.id}/items`, {
+        method: checked ? 'POST' : 'DELETE',
+        body: JSON.stringify({
+          targetId: toSaveItemId,
+          targetType: toSaveItemType,
+        }),
+      });
+      const alertText = checked ? `Saved to ${list.name}` : `Removed from ${list.name}`;
+      dispatch(
+        snackAlert(alertText, `${checked ? 'add' : 'remove'}_listitem_${list.name}_${toSaveItemId}`)
+      );
+    } catch (error) {
+      setListItemState(list.id, {
+        checked: !checked,
+      });
+      dispatch(snackAlertError(error));
+    } finally {
+      setListItemState(list.id, { requestInProgress: false });
+    }
+  };
+  const renderListPage = () => {
+    if (listsLoading) {
+      return (
+        <>
+          <div className="modal-card-content">
+            <div className="skeleton">
+              <div className="skeleton-bar"></div>
+              <div className="skeleton-bar"></div>
+              <div className="skeleton-bar"></div>
+              <div className="skeleton-bar"></div>
+              <div className="skeleton-bar"></div>
+            </div>
+          </div>
+        </>
+      );
+    }
+
+    const renderList = () => {
+      const renderItem = (list) => {
+        const { name, displayName } = list;
+        const htmlFor = `ch-${name}`;
+        return (
+          <div className="list-item" key={name}>
+            <label htmlFor={htmlFor}>{displayName}</label>
+            <input
+              className="checkbox"
+              id={htmlFor}
+              type="checkbox"
+              checked={listState[list.id].checked}
+              disabled={listState[list.id].requestInProgress}
+              onChange={(event) => handleItemClick(list, event)}
+            />
+          </div>
+        );
+      };
+      const elements = lists.map((list) => renderItem(list));
+      return <>{elements}</>;
+    };
+    return (
+      <>
+        <div className="modal-card-content">
+          <div className="save-modal-list is-custom-scrollbar is-v2">{renderList()}</div>
+        </div>
+        <div className="modal-card-actions">
+          <button onClick={() => setPage('new')}>Create new list</button>
+        </div>
+      </>
+    );
+  };
+
+  const renderNewPage = () => {
+    const switchTab = () => setPage('list');
+    return <EditListForm onCancel={switchTab} onSuccess={switchTab} />;
+  };
+
+  return (
+    <Modal open={open} onClose={handleClose}>
+      <div
+        className={
+          'modal-card save-modal is-compact-mobile' +
+          (page === 'new' ? ' is-page-new' : '') +
+          (page === 'list' ? ' is-page-list' : '')
+        }
+      >
+        <div className="modal-card-head">
+          <div className="modal-card-title">
+            {page === 'list' && 'Save to'}
+            {page === 'new' && 'Create list'}
+          </div>
+          <ButtonClose onClick={handleClose} />
+        </div>
+        {page === 'list' && renderListPage()}
+        {page === 'new' && renderNewPage()}
+      </div>
+    </Modal>
+  );
+};
+
+TheModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  toSaveItemId: PropTypes.string.isRequired,
+  toSaveItemType: PropTypes.string.isRequired,
+};
+
+export default SaveToListModal;

--- a/ui/src/components/Sidebar.jsx
+++ b/ui/src/components/Sidebar.jsx
@@ -105,6 +105,8 @@ const Sidebar = ({ isMobile = false }) => {
     };
   }, []);
 
+  const lists = useSelector((state) => state.main.lists.lists);
+
   return (
     <aside
       ref={ref}
@@ -280,6 +282,48 @@ const Sidebar = ({ isMobile = false }) => {
             My lists
           </Link>
           */}
+          {loggedIn && (
+            <>
+              <div className="sidebar-topic">My Lists</div>
+              {lists.map((list) => (
+                <Link
+                  key={list.id}
+                  className="sidebar-item with-image"
+                  to={`/@${user.username}/lists/${list.name}`}
+                >
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M21 5.25H14C13.59 5.25 13.25 4.91 13.25 4.5C13.25 4.09 13.59 3.75 14 3.75H21C21.41 3.75 21.75 4.09 21.75 4.5C21.75 4.91 21.41 5.25 21 5.25Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M21 10.25H14C13.59 10.25 13.25 9.91 13.25 9.5C13.25 9.09 13.59 8.75 14 8.75H21C21.41 8.75 21.75 9.09 21.75 9.5C21.75 9.91 21.41 10.25 21 10.25Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M21 15.25H3C2.59 15.25 2.25 14.91 2.25 14.5C2.25 14.09 2.59 13.75 3 13.75H21C21.41 13.75 21.75 14.09 21.75 14.5C21.75 14.91 21.41 15.25 21 15.25Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M21 20.25H3C2.59 20.25 2.25 19.91 2.25 19.5C2.25 19.09 2.59 18.75 3 18.75H21C21.41 18.75 21.75 19.09 21.75 19.5C21.75 19.91 21.41 20.25 21 20.25Z"
+                      fill="currentColor"
+                    />
+                    <path
+                      d="M7.92 3.5H5.08C3.68 3.5 3 4.18 3 5.58V8.43C3 9.83 3.68 10.51 5.08 10.51H7.93C9.33 10.51 10.01 9.83 10.01 8.43V5.58C10 4.18 9.32 3.5 7.92 3.5Z"
+                      fill="currentColor"
+                    />
+                  </svg>
+                  <span>{list.displayName}</span>
+                </Link>
+              ))}
+            </>
+          )}
           <div className="sidebar-topic">{loggedIn ? 'My communities' : 'Communities'}</div>
           {renderCommunitiesList()}
           {/*

--- a/ui/src/components/StaticPage.jsx
+++ b/ui/src/components/StaticPage.jsx
@@ -5,9 +5,9 @@ import Footer from './Footer';
 
 const StaticPage = ({ className, children, title, noWrap = false, ...props }) => {
   useEffect(() => {
-    document.body.classList.add('is-static-page');
+    document.body.classList.add('is-not-gray');
     return () => {
-      document.body.classList.remove('is-static-page');
+      document.body.classList.remove('is-not-gray');
     };
   }, []);
   return (

--- a/ui/src/hooks/index.js
+++ b/ui/src/hooks/index.js
@@ -2,16 +2,19 @@ import { useInsertionEffect, useReducer, useRef } from 'react';
 import { useEffect, useState } from 'react';
 import { useHistory } from 'react-router';
 import { useLocation } from 'react-router';
-import { usernameLegalLetters } from '../helper';
+import { APIError, mfetch, mfetchjson, usernameLegalLetters } from '../helper';
 import {
   muteCommunity,
   muteUser,
   selectIsCommunityMuted,
   selectIsUserMuted,
+  snackAlertError,
   unmuteCommunity,
   unmuteUser,
 } from '../slices/mainSlice';
 import { useDispatch, useSelector } from 'react-redux';
+import { selectUser, userAdded } from '../slices/usersSlice';
+import { selectUsersLists, usersListsAdded } from '../slices/listsSlice';
 
 export function useDelayedEffect(callback, deps, delay = 1000) {
   const [timer, setTimer] = useState(null);
@@ -26,8 +29,8 @@ export function useDelayedEffect(callback, deps, delay = 1000) {
   }, deps);
 }
 
-export function useInputUsername(maxLength) {
-  const [value, setValue] = useState('');
+export function useInputUsername(maxLength, initialUsername = '') {
+  const [value, setValue] = useState(initialUsername);
   const handleChange = (e) => {
     e.preventDefault();
     const { value } = e.target;
@@ -342,5 +345,87 @@ export function useMuteCommunity({ communityId, communityName }) {
     isMuted,
     toggleMute,
     displayText: (isMuted ? 'Unmute' : 'Mute') + ` /${communityName}`,
+  };
+}
+
+/**
+ * Fetches a user by calling the API. If the user is found in the Redux store,
+ * however, no networks calls are made and the user object is fetched from the
+ * store.
+ *
+ */
+export function useFetchUser(username, showSnackAlertOnError = true) {
+  const dispatch = useDispatch();
+  const user = useSelector(selectUser(username));
+  const [loading, setLoading] = useState(!user);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (user) {
+      return;
+    }
+    const f = async () => {
+      try {
+        setLoading(true);
+        const res = await mfetch(`/api/users/${username}`);
+        if (!res.ok) {
+          if (res.status === 404) {
+            setLoading(false);
+            return;
+          }
+          throw new APIError(res.status, await res.json());
+        }
+        dispatch(userAdded(await res.json()));
+      } catch (error) {
+        setError(error);
+        if (showSnackAlertOnError) {
+          dispatch(snackAlertError(error));
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    f();
+  }, [username]);
+
+  return {
+    user,
+    loading,
+    error,
+  };
+}
+
+export function useFetchUsersLists(username, showSnackAlertOnError = true) {
+  const dispatch = useDispatch();
+  const { lists, order, filter } = useSelector(selectUsersLists(username));
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (lists) {
+      return;
+    }
+    const f = async () => {
+      try {
+        setError(null);
+        const lists = await mfetchjson(
+          `/api/users/${username}/lists?sort=${order}&filter=${filter}`
+        );
+        dispatch(usersListsAdded(username, lists, order, filter));
+      } catch (error) {
+        setError(error);
+        if (showSnackAlertOnError) {
+          dispatch(snackAlertError(error));
+        }
+      }
+    };
+    f();
+  }, [username, order, filter]);
+
+  return {
+    lists,
+    order,
+    filter,
+    loading: !(lists && !error),
+    error,
   };
 }

--- a/ui/src/pages/Community/index.jsx
+++ b/ui/src/pages/Community/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useLocation } from 'react-router-dom';
+import { useHistory, useLocation, useParams } from 'react-router-dom';
 import Link from '../../components/Link';
 import { Helmet } from 'react-helmet-async';
 import MiniFooter from '../../components/MiniFooter';
@@ -22,7 +22,9 @@ import { useMuteCommunity } from '../../hooks';
 import Dropdown from '../../components/Dropdown';
 import { ButtonMore } from '../../components/Button';
 
-const Community = ({ name }) => {
+const Community = () => {
+  const { name } = useParams();
+
   const history = useHistory();
   const location = useLocation();
   const dispatch = useDispatch();

--- a/ui/src/pages/Lists/List.jsx
+++ b/ui/src/pages/Lists/List.jsx
@@ -1,0 +1,515 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+import Sidebar from '../../components/Sidebar';
+import MiniFooter from '../../components/MiniFooter';
+import { Helmet } from 'react-helmet-async';
+import Link from '../../components/Link';
+import Modal from '../../components/Modal';
+import { ButtonClose, ButtonMore } from '../../components/Button';
+import Input, { InputWithCount } from '../../components/Input';
+import { APIError, dateString1, mfetch, mfetchjson, stringCount, timeAgo } from '../../helper';
+import { useDispatch, useSelector } from 'react-redux';
+import { listsAdded, snackAlertError } from '../../slices/mainSlice';
+import {
+  FeedItem,
+  feedInViewItemsUpdated,
+  feedItemHeightChanged,
+  feedReloaded,
+  feedUpdated,
+  selectFeed,
+  selectFeedInViewItems,
+} from '../../slices/feedsSlice';
+import Feed from '../../components/Feed';
+import { MemorizedPostCard } from '../../components/PostCard/PostCard';
+import { selectUser } from '../../slices/usersSlice';
+import { MemorizedComment } from '../User/Comment';
+import PageLoading from '../../components/PageLoading';
+import NotFound from '../NotFound';
+import { listAdded, selectList } from '../../slices/listsSlice';
+import { useInputUsername } from '../../hooks';
+import { usernameMaxLength } from '../../config';
+import { useHistory } from 'react-router-dom';
+import Dropdown from '../../components/Dropdown';
+
+const List = () => {
+  const dispatch = useDispatch();
+  const { username, listName: listname } = useParams();
+
+  const [editModalOpen, setEditModalOpen] = useState(false);
+
+  const list = useSelector(selectList(username, listname));
+  const [listLoading, setListLoading] = useState(list ? 'loaded' : 'loading');
+
+  const listEndpoint = `/api/users/${username}/lists/${listname}`;
+  useEffect(() => {
+    if (listLoading !== 'loading') {
+      return;
+    }
+    const f = async () => {
+      try {
+        const res = await mfetch(listEndpoint);
+        if (!res.ok) {
+          if (res.status === 404) {
+            setListLoading('notfound');
+            return;
+          }
+          throw new Error(await res.text());
+        }
+        dispatch(listAdded(username, await res.json()));
+        setListLoading('loaded');
+      } catch (error) {
+        dispatch(snackAlertError(error));
+        setListLoading('error');
+      }
+    };
+    f();
+  }, [listLoading]);
+  useEffect(() => {
+    if (!list || list.name !== listname || list.username !== username) {
+      setListLoading('loading');
+    }
+  }, [list, username, listname]);
+
+  const feedEndpoint = `${listEndpoint}/items`;
+  const feed = useSelector(selectFeed(feedEndpoint));
+  const setFeed = (res) => {
+    const feedItems = (res.items ?? []).map(
+      (item) => new FeedItem(item.targetItem, item.targetType, item.id)
+    );
+    dispatch(feedUpdated(feedEndpoint, feedItems, res.next ?? null));
+  };
+
+  const feedLoading = feed ? feed.loading : true;
+  const [feedLoadingError, setFeedLoadingError] = useState(null);
+
+  useEffect(() => {
+    if (!feedLoading) {
+      return;
+    }
+    const f = async () => {
+      try {
+        const res = await mfetch(feedEndpoint);
+        if (!res.ok) {
+          if (res.status === 404) {
+            setFeedLoadingError(new Error('feed not found'));
+            return;
+          }
+        }
+        setFeed(await res.json());
+      } catch (error) {
+        setFeedLoadingError(error);
+        dispatch(snackAlertError(error));
+      }
+    };
+    f();
+  }, [feedEndpoint, feedLoading]);
+
+  const [feedReloading, setFeedReloading] = useState(false);
+  const fetchNextItems = async () => {
+    if (feedReloading) return;
+    try {
+      setFeedReloading(true);
+      const res = await mfetchjson(`${feedEndpoint}?next=${feed.next}`);
+      setFeed(res);
+    } catch (error) {
+      dispatch(snackAlertError(error));
+    } finally {
+      setFeedReloading(false);
+    }
+  };
+
+  const user = useSelector(selectUser(username));
+  const handleRenderItem = (item) => {
+    if (item.type === 'post') {
+      return <MemorizedPostCard initialPost={item.item} disableEmbeds={user && user.embedsOff} />;
+    }
+    if (item.type === 'comment') {
+      return <MemorizedComment comment={item.item} />;
+    }
+  };
+
+  const handleItemHeightChange = (height, item) => {
+    dispatch(feedItemHeightChanged(item.key, height));
+  };
+
+  const itemsInitiallyInView = useSelector(selectFeedInViewItems(feedEndpoint));
+  const handleSaveVisibleItems = (items) => {
+    dispatch(feedInViewItemsUpdated(feedEndpoint, items));
+  };
+
+  const handleRemoveAllItems = async () => {
+    if (!confirm('Are you sure you want to remove all items from the list?')) {
+      return;
+    }
+    try {
+      await mfetchjson(feedEndpoint, { method: 'DELETE' });
+      dispatch(feedReloaded(feedEndpoint));
+    } catch (error) {
+      dispatch(snackAlertError(error));
+    }
+  };
+
+  const history = useHistory();
+  const handleDeleteList = async () => {
+    if (!confirm('Are you sure you want to delete the list?')) {
+      return;
+    }
+    try {
+      await mfetchjson(listEndpoint, { method: 'DELETE' });
+      const res = await mfetchjson('/api/_initial');
+      dispatch(listsAdded(res.lists));
+      history.replace(`/@${list.username}/lists/${name}`);
+    } catch (error) {
+      dispatch(snackAlertError(error));
+    }
+  };
+
+  if (feedLoading || feedLoadingError || listLoading !== 'loaded' || !list) {
+    console.log('loading: ', listLoading);
+    if (listLoading === 'notfound') {
+      return <NotFound />;
+    }
+    return <PageLoading />;
+  }
+
+  return (
+    <div className="page-content wrap page-grid page-list">
+      <EditListModal list={list} open={editModalOpen} onClose={() => setEditModalOpen(false)} />
+      <Helmet>
+        <title>{`${listname} of @${username}`}</title>
+      </Helmet>
+      <Sidebar />
+      <main className="page-middle">
+        <header className="card card-padding list-head">
+          <div className="list-head-main">
+            <div className="list-head-top">
+              <h1>{list.displayName}</h1>
+              {!list.public && <div>Private</div>}
+            </div>
+            <Link to={`/@${list.username}`} className="list-head-user">
+              @{list.username}
+            </Link>
+            <div className="list-head-desc">{list.description}</div>
+          </div>
+          <div className="list-head-actions">
+            <button onClick={() => setEditModalOpen(true)}>Edit list</button>
+            <Dropdown target={<ButtonMore style={{ background: 'var(--color-button)' }} />}>
+              <div className="dropdown-list">
+                <div className="button-clear dropdown-item" onClick={handleRemoveAllItems}>
+                  Remove all items
+                </div>
+                <div className="button-clear dropdown-item" onClick={handleDeleteList}>
+                  Delete list
+                </div>
+              </div>
+            </Dropdown>
+          </div>
+        </header>
+        <div className="lists-feed">
+          {/*<PostsFeed feedType="all" />*/}
+
+          <Feed
+            loading={feedLoading}
+            items={feed ? feed.items : []}
+            hasMore={Boolean(feed ? feed.next : false)}
+            onNext={fetchNextItems}
+            isMoreItemsLoading={feedReloading}
+            onRenderItem={handleRenderItem}
+            onItemHeightChange={handleItemHeightChange}
+            itemsInitiallyInView={itemsInitiallyInView}
+            onSaveVisibleItems={handleSaveVisibleItems}
+          />
+        </div>
+      </main>
+      <aside className="sidebar-right">
+        <div className="card card-sub list-summary">
+          <div className="card-head">
+            <div className="card-title">List summary</div>
+          </div>
+          <div className="card-content">
+            <div className="card-list-item">
+              {SVGs.comment}
+              <div>{stringCount(list.numItems, false, 'total item')}</div>
+            </div>
+            <div className="card-list-item">
+              {SVGs.calendar}
+              <div>{`Created on ${dateString1(list.createdAt)}`}</div>
+            </div>
+            <div className="card-list-item">
+              {SVGs.clock}
+              <div>{`Last updated ${timeAgo(list.lastUpdatedAt)}`}</div>
+            </div>
+          </div>
+        </div>
+        <MiniFooter />
+      </aside>
+    </div>
+  );
+};
+
+export default List;
+
+const EditListModal = ({ list, open, onClose }) => {
+  return (
+    <Modal open={open} onClose={onClose}>
+      <div className="modal-card edit-list-modal is-compact-mobile">
+        <div className="modal-card-head">
+          <div className="modal-card-title">Edit list</div>
+          <ButtonClose onClick={onClose} />
+        </div>
+        <EditListForm list={list} onCancel={onClose} onSuccess={onClose} />
+      </div>
+    </Modal>
+  );
+};
+
+EditListModal.propTypes = {
+  list: PropTypes.object.isRequired,
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+const SVGs = {
+  comment: (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M21 7V17C21 20 19.5 22 16 22H8C4.5 22 3 20 3 17V7C3 4 4.5 2 8 2H16C19.5 2 21 4 21 7Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14.5 4.5V6.5C14.5 7.6 15.4 8.5 16.5 8.5H18.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 13H12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8 17H16"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  ),
+  calendar: (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M8 5.75C7.59 5.75 7.25 5.41 7.25 5V2C7.25 1.59 7.59 1.25 8 1.25C8.41 1.25 8.75 1.59 8.75 2V5C8.75 5.41 8.41 5.75 8 5.75Z"
+        fill="currentColor"
+      />
+      <path
+        d="M16 5.75C15.59 5.75 15.25 5.41 15.25 5V2C15.25 1.59 15.59 1.25 16 1.25C16.41 1.25 16.75 1.59 16.75 2V5C16.75 5.41 16.41 5.75 16 5.75Z"
+        fill="currentColor"
+      />
+      <path
+        d="M8.5 14.4984C8.37 14.4984 8.24 14.4684 8.12 14.4184C7.99 14.3684 7.89 14.2983 7.79 14.2083C7.61 14.0183 7.5 13.7684 7.5 13.4984C7.5 13.3684 7.53 13.2384 7.58 13.1184C7.63 12.9984 7.7 12.8884 7.79 12.7884C7.89 12.6984 7.99 12.6283 8.12 12.5783C8.48 12.4283 8.93 12.5084 9.21 12.7884C9.39 12.9784 9.5 13.2384 9.5 13.4984C9.5 13.5584 9.49 13.6284 9.48 13.6984C9.47 13.7584 9.45 13.8184 9.42 13.8784C9.4 13.9384 9.37 13.9984 9.33 14.0584C9.3 14.1084 9.25 14.1583 9.21 14.2083C9.02 14.3883 8.76 14.4984 8.5 14.4984Z"
+        fill="currentColor"
+      />
+      <path
+        d="M12 14.4989C11.87 14.4989 11.74 14.4689 11.62 14.4189C11.49 14.3689 11.39 14.2989 11.29 14.2089C11.11 14.0189 11 13.7689 11 13.4989C11 13.3689 11.03 13.2389 11.08 13.1189C11.13 12.9989 11.2 12.8889 11.29 12.7889C11.39 12.6989 11.49 12.6289 11.62 12.5789C11.98 12.4189 12.43 12.5089 12.71 12.7889C12.89 12.9789 13 13.2389 13 13.4989C13 13.5589 12.99 13.6289 12.98 13.6989C12.97 13.7589 12.95 13.8189 12.92 13.8789C12.9 13.9389 12.87 13.9989 12.83 14.0589C12.8 14.1089 12.75 14.1589 12.71 14.2089C12.52 14.3889 12.26 14.4989 12 14.4989Z"
+        fill="currentColor"
+      />
+      <path
+        d="M15.5 14.4989C15.37 14.4989 15.24 14.4689 15.12 14.4189C14.99 14.3689 14.89 14.2989 14.79 14.2089C14.75 14.1589 14.71 14.1089 14.67 14.0589C14.63 13.9989 14.6 13.9389 14.58 13.8789C14.55 13.8189 14.53 13.7589 14.52 13.6989C14.51 13.6289 14.5 13.5589 14.5 13.4989C14.5 13.2389 14.61 12.9789 14.79 12.7889C14.89 12.6989 14.99 12.6289 15.12 12.5789C15.49 12.4189 15.93 12.5089 16.21 12.7889C16.39 12.9789 16.5 13.2389 16.5 13.4989C16.5 13.5589 16.49 13.6289 16.48 13.6989C16.47 13.7589 16.45 13.8189 16.42 13.8789C16.4 13.9389 16.37 13.9989 16.33 14.0589C16.3 14.1089 16.25 14.1589 16.21 14.2089C16.02 14.3889 15.76 14.4989 15.5 14.4989Z"
+        fill="currentColor"
+      />
+      <path
+        d="M8.5 17.9992C8.37 17.9992 8.24 17.9692 8.12 17.9192C8 17.8692 7.89 17.7992 7.79 17.7092C7.61 17.5192 7.5 17.2592 7.5 16.9992C7.5 16.8692 7.53 16.7392 7.58 16.6192C7.63 16.4892 7.7 16.3792 7.79 16.2892C8.16 15.9192 8.84 15.9192 9.21 16.2892C9.39 16.4792 9.5 16.7392 9.5 16.9992C9.5 17.2592 9.39 17.5192 9.21 17.7092C9.02 17.8892 8.76 17.9992 8.5 17.9992Z"
+        fill="currentColor"
+      />
+      <path
+        d="M12 17.9992C11.74 17.9992 11.48 17.8892 11.29 17.7092C11.11 17.5192 11 17.2592 11 16.9992C11 16.8692 11.03 16.7392 11.08 16.6192C11.13 16.4892 11.2 16.3792 11.29 16.2892C11.66 15.9192 12.34 15.9192 12.71 16.2892C12.8 16.3792 12.87 16.4892 12.92 16.6192C12.97 16.7392 13 16.8692 13 16.9992C13 17.2592 12.89 17.5192 12.71 17.7092C12.52 17.8892 12.26 17.9992 12 17.9992Z"
+        fill="currentColor"
+      />
+      <path
+        d="M15.5 18.0009C15.24 18.0009 14.98 17.8909 14.79 17.7109C14.7 17.6209 14.63 17.5109 14.58 17.3809C14.53 17.2609 14.5 17.1309 14.5 17.0009C14.5 16.8709 14.53 16.7409 14.58 16.6209C14.63 16.4909 14.7 16.3809 14.79 16.2909C15.02 16.0609 15.37 15.9509 15.69 16.0209C15.76 16.0309 15.82 16.0509 15.88 16.0809C15.94 16.1009 16 16.1309 16.06 16.1709C16.11 16.2009 16.16 16.2509 16.21 16.2909C16.39 16.4809 16.5 16.7409 16.5 17.0009C16.5 17.2609 16.39 17.5209 16.21 17.7109C16.02 17.8909 15.76 18.0009 15.5 18.0009Z"
+        fill="currentColor"
+      />
+      <path
+        d="M20.5 9.83984H3.5C3.09 9.83984 2.75 9.49984 2.75 9.08984C2.75 8.67984 3.09 8.33984 3.5 8.33984H20.5C20.91 8.33984 21.25 8.67984 21.25 9.08984C21.25 9.49984 20.91 9.83984 20.5 9.83984Z"
+        fill="currentColor"
+      />
+      <path
+        d="M16 22.75H8C4.35 22.75 2.25 20.65 2.25 17V8.5C2.25 4.85 4.35 2.75 8 2.75H16C19.65 2.75 21.75 4.85 21.75 8.5V17C21.75 20.65 19.65 22.75 16 22.75ZM8 4.25C5.14 4.25 3.75 5.64 3.75 8.5V17C3.75 19.86 5.14 21.25 8 21.25H16C18.86 21.25 20.25 19.86 20.25 17V8.5C20.25 5.64 18.86 4.25 16 4.25H8Z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+  clock: (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 22.75C6.07 22.75 1.25 17.93 1.25 12C1.25 6.07 6.07 1.25 12 1.25C17.93 1.25 22.75 6.07 22.75 12C22.75 17.93 17.93 22.75 12 22.75ZM12 2.75C6.9 2.75 2.75 6.9 2.75 12C2.75 17.1 6.9 21.25 12 21.25C17.1 21.25 21.25 17.1 21.25 12C21.25 6.9 17.1 2.75 12 2.75Z"
+        fill="currentColor"
+      />
+      <path
+        d="M15.7106 15.9317C15.5806 15.9317 15.4506 15.9017 15.3306 15.8217L12.2306 13.9717C11.4606 13.5117 10.8906 12.5017 10.8906 11.6117V7.51172C10.8906 7.10172 11.2306 6.76172 11.6406 6.76172C12.0506 6.76172 12.3906 7.10172 12.3906 7.51172V11.6117C12.3906 11.9717 12.6906 12.5017 13.0006 12.6817L16.1006 14.5317C16.4606 14.7417 16.5706 15.2017 16.3606 15.5617C16.2106 15.8017 15.9606 15.9317 15.7106 15.9317Z"
+        fill="currentColor"
+      />
+    </svg>
+  ),
+};
+
+export const EditListForm = ({ list, onCancel, onSuccess }) => {
+  const user = useSelector((state) => state.main.user);
+  const dispatch = useDispatch();
+
+  const [isPublic, setIsPublic] = useState(list ? list.public : false);
+
+  const [name, handleNameChange] = useInputUsername(usernameMaxLength, list ? list.name : '');
+  const [nameError, setNameError] = useState(null);
+  const handleNameBlur = async () => {
+    if (list && list.name === name) {
+      setNameError(null);
+      return;
+    }
+    try {
+      const res = await mfetch(`/api/users/${user.username}/lists/${name}`);
+      if (!res.ok) {
+        if (res.status === 404) {
+          setNameError(null);
+          return;
+        }
+        throw new APIError(res.status, await res.json());
+      }
+      setNameError(`List with name ${name} already exists.`);
+    } catch (error) {
+      dispatch(snackAlertError(error));
+    }
+  };
+
+  const [displayName, setDisplayName] = useState(list ? list.displayName : '');
+  const [description, setDescription] = useState(list ? list.description : '');
+
+  const createNewList = async () => {
+    const newLists = await mfetchjson(`/api/users/${user.username}/lists`, {
+      method: 'POST',
+      body: JSON.stringify({
+        name,
+        displayName,
+        description,
+        public: isPublic,
+      }),
+    });
+    dispatch(listsAdded(newLists));
+  };
+
+  const history = useHistory();
+  const updateList = async () => {
+    const newList = await mfetchjson(`/api/lists/${list.id}`, {
+      method: 'PUT',
+      body: JSON.stringify({
+        name,
+        displayName,
+        description,
+        public: isPublic,
+      }),
+    });
+    const res = await mfetchjson('/api/_initial');
+    dispatch(listsAdded(res.lists));
+    history.replace(`/@${list.username}/lists/${name}`);
+    dispatch(listAdded(list.username, newList));
+  };
+
+  const [formDisabled, setFormDisabled] = useState(false);
+  const handleSubmit = async (event) => {
+    if (event) {
+      event.preventDefault();
+    }
+    if (formDisabled) {
+      return;
+    }
+    if (name === '') {
+      setNameError('Name cannot be empty.');
+      return;
+    }
+    setFormDisabled(true);
+    try {
+      if (list) {
+        await updateList();
+      } else {
+        await createNewList();
+      }
+    } catch (error) {
+      dispatch(snackAlertError(error));
+    }
+    setFormDisabled(false);
+    if (onSuccess) {
+      onSuccess();
+    }
+  };
+
+  return (
+    <>
+      <form className="modal-card-content" onSubmit={handleSubmit}>
+        <div className="edit-list-modal-form" onSubmit={handleSubmit}>
+          <InputWithCount
+            label="Name"
+            maxLength={usernameMaxLength}
+            description="Name will be part of the URL of the list."
+            error={nameError}
+            value={name}
+            onChange={handleNameChange}
+            onBlur={handleNameBlur}
+            autoFocus
+            style={{ marginBottom: 0 }}
+            autoComplete="name"
+          />
+          <Input
+            label="Display name"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+          />
+          <div className="checkbox is-check-last">
+            <label htmlFor="pub">Public</label>
+            <input
+              className="switch"
+              type="checkbox"
+              id="pub"
+              checked={isPublic}
+              onChange={(e) => setIsPublic(e.target.checked)}
+            />
+          </div>
+          <div className="input-with-label">
+            <div className="input-label-box">
+              <div className="label">Description</div>
+            </div>
+            <textarea
+              rows="5"
+              placeholder=""
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+        </div>
+      </form>
+      <div className="modal-card-actions">
+        <button className="button-main" onClick={handleSubmit} disabled={formDisabled}>
+          {list ? 'Save' : 'Create'}
+        </button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    </>
+  );
+};
+
+EditListForm.propTypes = {
+  list: PropTypes.object,
+  onCancel: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func,
+};

--- a/ui/src/pages/Lists/Lists.jsx
+++ b/ui/src/pages/Lists/Lists.jsx
@@ -1,0 +1,188 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useParams } from 'react-router-dom';
+import Sidebar from '../../components/Sidebar';
+import Link from '../../components/Link';
+import Dropdown from '../../components/Dropdown';
+import { useDispatch, useSelector } from 'react-redux';
+import { snackAlertError } from '../../slices/mainSlice';
+import { mfetch, mfetchjson, stringCount, timeAgo } from '../../helper';
+import { selectUser } from '../../slices/usersSlice';
+import { useFetchUser, useFetchUsersLists } from '../../hooks';
+import PageLoading from '../../components/PageLoading';
+import NotFound from '../NotFound';
+import { listsFilterChanged, listsOrderChanged } from '../../slices/listsSlice';
+
+const Lists = () => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    document.body.classList.add('is-not-gray');
+    return () => {
+      document.body.classList.remove('is-not-gray');
+    };
+  }, []);
+
+  const { username } = useParams();
+  const { user, loading: userLoading, error: userError } = useFetchUser(username);
+  const {
+    lists,
+    order,
+    filter,
+    loading: listsLoading,
+    error: listsError,
+  } = useFetchUsersLists(username);
+
+  if (userLoading || listsLoading) {
+    return <PageLoading />;
+  }
+
+  if (userError !== null || listsError !== null) {
+    return (
+      <div className="page-content wrap">
+        <h1>Something went wrong!</h1>
+      </div>
+    );
+  }
+
+  if (!user) {
+    // Page loaded but user not found.
+    return <NotFound />;
+  }
+
+  const orderOptions = {
+    name: 'A-Z',
+    lastAdded: 'Last added',
+  };
+  const renderOrderDropdown = () => {
+    const items = [];
+    for (const [key, value] of Object.entries(orderOptions)) {
+      items.push(
+        <div
+          key={key}
+          className="dropdown-item"
+          onClick={() => dispatch(listsOrderChanged(username, key))}
+        >
+          {value}
+        </div>
+      );
+    }
+    return (
+      <Dropdown target={orderOptions[order]}>
+        <div className="dropdown-list">{items}</div>
+      </Dropdown>
+    );
+  };
+
+  const filterOptions = {
+    all: 'All',
+    public: 'Public',
+    private: 'Private',
+  };
+  const renderFilterDropdown = () => {
+    console.log(`filter is: `, filter);
+    const items = [];
+    for (const [key, value] of Object.entries(filterOptions)) {
+      items.push(
+        <div
+          key={key}
+          className="dropdown-item"
+          onClick={() => dispatch(listsFilterChanged(username, key))}
+        >
+          {value}
+        </div>
+      );
+    }
+    return (
+      <Dropdown target={filterOptions[filter]}>
+        <div className="dropdown-list">{items}</div>
+      </Dropdown>
+    );
+  };
+
+  return (
+    <div className="page-content wrap page-grid page-lists">
+      <Sidebar />
+      <main>
+        <div className="lists-head">
+          <h1>
+            <Link to={`/@${username}`}>@{username}</Link>
+            {"'s lists"}
+          </h1>
+        </div>
+        <section className="lists-main">
+          <div className="lists-main-head">
+            <div className="left">
+              {renderOrderDropdown()}
+              {renderFilterDropdown()}
+            </div>
+          </div>
+          <div className="lists-main-main">
+            {lists.map((list) => (
+              <ListThumbnail key={list.id} list={list} />
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Lists;
+
+const ListThumbnail = ({ list }) => {
+  // TODO: Display list private status.
+  const { username, name, displayName } = list;
+  return (
+    <Link className="list-thumb" to={`/@${username}/lists/${name}`}>
+      <div className="list-thumb-top">
+        <div className="list-thumb-image is-default">
+          {/*
+          <img
+            src="https://discuit.net/images/17cad58e3fb9872ece91fc87.jpeg?sig=hgUa8EBH96UoIW4YsR5qASk36arQsP_iELgJmV18QBw"
+            alt="Cutest little doggie"
+          />*/}
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 5.25H14C13.59 5.25 13.25 4.91 13.25 4.5C13.25 4.09 13.59 3.75 14 3.75H21C21.41 3.75 21.75 4.09 21.75 4.5C21.75 4.91 21.41 5.25 21 5.25Z"
+              fill="currentColor"
+            ></path>
+            <path
+              d="M21 10.25H14C13.59 10.25 13.25 9.91 13.25 9.5C13.25 9.09 13.59 8.75 14 8.75H21C21.41 8.75 21.75 9.09 21.75 9.5C21.75 9.91 21.41 10.25 21 10.25Z"
+              fill="currentColor"
+            ></path>
+            <path
+              d="M21 15.25H3C2.59 15.25 2.25 14.91 2.25 14.5C2.25 14.09 2.59 13.75 3 13.75H21C21.41 13.75 21.75 14.09 21.75 14.5C21.75 14.91 21.41 15.25 21 15.25Z"
+              fill="currentColor"
+            ></path>
+            <path
+              d="M21 20.25H3C2.59 20.25 2.25 19.91 2.25 19.5C2.25 19.09 2.59 18.75 3 18.75H21C21.41 18.75 21.75 19.09 21.75 19.5C21.75 19.91 21.41 20.25 21 20.25Z"
+              fill="currentColor"
+            ></path>
+            <path
+              d="M7.92 3.5H5.08C3.68 3.5 3 4.18 3 5.58V8.43C3 9.83 3.68 10.51 5.08 10.51H7.93C9.33 10.51 10.01 9.83 10.01 8.43V5.58C10 4.18 9.32 3.5 7.92 3.5Z"
+              fill="currentColor"
+            ></path>
+          </svg>
+        </div>
+      </div>
+      <div className="list-thumb-bottom">
+        <div className="list-thumb-name">
+          <span className="is-name">{displayName}</span>
+          <span className="is-age">{timeAgo(list.lastUpdatedAt, '', false, true)}</span>
+        </div>
+        <div className="list-thumb-count">{stringCount(list.numItems, false, 'item')}</div>
+      </div>
+    </Link>
+  );
+};
+
+ListThumbnail.propTypes = {
+  list: PropTypes.object.isRequired,
+};

--- a/ui/src/pages/Lists/index.jsx
+++ b/ui/src/pages/Lists/index.jsx
@@ -1,0 +1,4 @@
+import Lists from './Lists';
+import List from './List';
+
+export { Lists, List };

--- a/ui/src/pages/Modtools/index.jsx
+++ b/ui/src/pages/Modtools/index.jsx
@@ -29,7 +29,7 @@ function isActiveCls(className, isActive, activeClass = 'is-active') {
 
 const Modtools = () => {
   const dispatch = useDispatch();
-  const { communityName } = useParams();
+  const { name: communityName } = useParams();
 
   const user = useSelector((state) => state.main.user);
 

--- a/ui/src/pages/Post/Comment.jsx
+++ b/ui/src/pages/Post/Comment.jsx
@@ -7,7 +7,12 @@ import AddComment from './AddComment';
 import { useDispatch } from 'react-redux';
 import { kRound, mfetchjson, stringCount, toTitleCase, userGroupSingular } from '../../helper';
 import Dropdown from '../../components/Dropdown';
-import { loginPromptToggled, snackAlert, snackAlertError } from '../../slices/mainSlice';
+import {
+  loginPromptToggled,
+  saveToListModalOpened,
+  snackAlert,
+  snackAlertError,
+} from '../../slices/mainSlice';
 import TimeAgo from '../../components/TimeAgo';
 import ModalConfirm from '../../components/Modal/ModalConfirm';
 import ReportModal from '../../components/ReportModal';
@@ -342,6 +347,10 @@ const Comment = ({
     );
   }
 
+  const handleSave = () => {
+    dispatch(saveToListModalOpened(comment.id, 'comment'));
+  };
+
   const upCls = {};
   const downCls = {};
   if (vote === true) {
@@ -618,6 +627,11 @@ const Comment = ({
                       Report
                     </div>
                   )}
+                  {loggedIn && (
+                    <div className="dropdown-item" onClick={handleSave}>
+                      Save to list
+                    </div>
+                  )}
                   {isAdmin && (
                     <>
                       <div className="dropdown-item is-topic">Admin actions</div>
@@ -649,6 +663,11 @@ const Comment = ({
               )}
               {showReport && (
                 <ReportModal target={comment} targetType="comment" disabled={isBanned} />
+              )}
+              {loggedIn && (
+                <button className="button-text" onClick={handleSave}>
+                  Save
+                </button>
               )}
               {isAdmin && (
                 <Dropdown

--- a/ui/src/pages/Post/PostDeleteModal.jsx
+++ b/ui/src/pages/Post/PostDeleteModal.jsx
@@ -13,7 +13,7 @@ const PostDeleteModal = ({ open, onClose, onDelete, postType, canDeleteContent =
 
   return (
     <Modal open={open} onClose={onClose}>
-      <div className="modal-card is-compact-mobile modal-delete-post">
+      <div className="modal-card is-compact-mobile is-center modal-delete-post">
         <div className="modal-card-head">
           <div className="modal-card-title">Delete post</div>
           <ButtonClose onClick={onClose} />

--- a/ui/src/pages/Post/index.jsx
+++ b/ui/src/pages/Post/index.jsx
@@ -12,7 +12,7 @@ import {
   userGroupSingular,
 } from '../../helper';
 import { useIsMobile } from '../../hooks';
-import { snackAlert, snackAlertError } from '../../slices/mainSlice';
+import { saveToListModalOpened, snackAlert, snackAlertError } from '../../slices/mainSlice';
 import AddComment from './AddComment';
 import ReportModal from '../../components/ReportModal';
 import Sidebar from '../../components/Sidebar';
@@ -402,6 +402,14 @@ const Post = () => {
             <div className={'post-card-bottom' + (!hasImage ? ' has-no-img' : '')}>
               <div className="left">
                 <PostShareButton post={post} />
+                {loggedIn && (
+                  <button
+                    className="button-text"
+                    onClick={() => dispatch(saveToListModalOpened(post.id, 'post'))}
+                  >
+                    Save
+                  </button>
+                )}
                 {postOwner && (
                   <button
                     className="button-text"
@@ -475,6 +483,12 @@ const Post = () => {
                 {isAdmin && (
                   <Dropdown target={<button className="button-red">Admin actions</button>}>
                     <div className="dropdown-list">
+                      <button
+                        className="button-clear dropdown-item"
+                        onClick={() => alert(`ID: ${post.id}`)}
+                      >
+                        ID
+                      </button>
                       <button
                         className="button-clear dropdown-item"
                         onClick={() => handleLock('admins')}

--- a/ui/src/pages/User/BadgesList.jsx
+++ b/ui/src/pages/User/BadgesList.jsx
@@ -31,7 +31,7 @@ function BadgesList({ user }) {
   return (
     <div className="user-badges">
       <Modal open={modalOpen} onClose={handleModalClose}>
-        <div className="modal-card is-compact-mobile modal-badges">
+        <div className="modal-card is-compact-mobile is-center modal-badges">
           <div className="modal-badges-head">
             <ButtonClose className="modal-badges-close" onClick={handleModalClose} />
             <Badge badge={selectedBadge} />

--- a/ui/src/pages/User/index.jsx
+++ b/ui/src/pages/User/index.jsx
@@ -23,7 +23,7 @@ import PageLoading from '../../components/PageLoading';
 import Feed from '../../components/Feed';
 import NotFound from '../NotFound';
 import { Helmet } from 'react-helmet-async';
-import { Link, useHistory, useLocation } from 'react-router-dom';
+import { Link, useHistory, useLocation, useParams } from 'react-router-dom';
 import CommunityLink from '../../components/PostCard/CommunityLink';
 import { useMuteUser } from '../../hooks';
 import UserProPic from '../../components/UserProPic';
@@ -38,7 +38,9 @@ function formatFilterText(filter = '') {
   return 'overview';
 }
 
-const User = ({ username }) => {
+const User = () => {
+  const { username } = useParams();
+
   const dispatch = useDispatch();
   const history = useHistory();
 

--- a/ui/src/reducer.js
+++ b/ui/src/reducer.js
@@ -2,10 +2,10 @@ import { combineReducers } from 'redux';
 import commentsReducer from './slices/commentsSlice';
 import communitiesReducer from './slices/communitiesSlice';
 import feedsReducer from './slices/feedsSlice';
-
 import mainReducer from './slices/mainSlice';
 import postsReducer from './slices/postsSlice';
 import usersReducer from './slices/usersSlice';
+import listsReducer from './slices/listsSlice';
 
 const rootReducer = combineReducers({
   main: mainReducer,
@@ -14,6 +14,7 @@ const rootReducer = combineReducers({
   comments: commentsReducer,
   communities: communitiesReducer,
   users: usersReducer,
+  lists: listsReducer,
 });
 
 export default rootReducer;

--- a/ui/src/scss/_base.scss
+++ b/ui/src/scss/_base.scss
@@ -235,6 +235,10 @@ body {
         --fs-l: 1.7rem;
         --fs-xl: 1.8rem;
     }
+
+    &.is-not-gray {
+        background: var(--color-bg);
+    }
 }
 
 @mixin custom-scrollbar {
@@ -656,7 +660,7 @@ button,
     &.button-icon {
         &:hover,
         &.is-active {
-            background: var(--color-button);
+            background: var(--color-button-hover);
         }
     }
     &.button-icon-simple {
@@ -676,6 +680,13 @@ button,
         span {
             height: var(--button-icon-size);
             margin-left: 8px;
+        }
+        &.is-text-first {
+            flex-direction: row-reverse;
+            span {
+                margin-left: 0;
+                margin-right: 8px;
+            }
         }
     }
     &:disabled,

--- a/ui/src/scss/_components.scss
+++ b/ui/src/scss/_components.scss
@@ -431,8 +431,8 @@
                         }
                     }
                     .modal-card-content {
-                        align-items: center;
-                        text-align: center;
+                        // align-items: center;
+                        // text-align: center;
                         padding-top: 0.5rem;
                         padding-left: 2rem;
                         padding-right: 2rem;
@@ -446,11 +446,11 @@
                             width: 100%;
                             margin: 0;
                             background: var(--color-bg);
-                            color: var(--color-gray);
+                            // color: var(--color-gray);
                             border-right: var(--seperator);
                             height: 45px;
                             border-radius: 0;
-                            opacity: 0.8;
+                            // opacity: 0.8;
                             &.button-main {
                                 color: var(--color-brand);
                                 opacity: 1;
@@ -462,6 +462,12 @@
                             &:last-child {
                                 border-bottom-left-radius: var(--border-radius);
                             }
+                        }
+                    }
+                    &.is-center {
+                        .modal-card-content {
+                            align-items: center;
+                            text-align: center;
                         }
                     }
                 }
@@ -519,6 +525,12 @@
     position: relative;
     z-index: 10;
     > .dropdown-target {
+    }
+    .dropdown-target {
+        button,
+        .button {
+            font-weight: inherit;
+        }
     }
     > .dropdown-menu {
         display: none;
@@ -623,6 +635,9 @@
         // transition: all var(--t-time-button);
         color: inherit;
         text-decoration: inherit;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
         &:hover,
         &.is-active {
             background: rgba(var(--base-fg), 0.1);
@@ -639,6 +654,9 @@
             }
             img {
                 border-radius: 50%;
+            }
+            span {
+                width: 100%;
             }
         }
         &.is-m {
@@ -1025,6 +1043,80 @@
         .ptr--icon {
             color: var(--color-text);
             opacity: 0.3;
+        }
+    }
+}
+
+.modal {
+    .save-modal {
+        width: 270px;
+        min-width: initial;
+        --list-item-height: 35px;
+        .modal-card-content {
+            padding: 0;
+        }
+        .save-modal-list {
+            padding: var(--card-padding);
+            margin-bottom: var(--card-padding);
+            display: flex;
+            flex-direction: column;
+            max-height: 30vh;
+            overflow-y: scroll;
+            padding-bottom: 0;
+            margin-bottom: 0;
+            .list-item {
+                display: flex;
+                justify-content: space-between;
+                cursor: pointer;
+                padding: 6px 0; // 6px 8px;
+                height: var(--list-item-height);
+                label {
+                    flex-grow: 1;
+                    cursor: pointer;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                    margin-right: 8px;
+                }
+            }
+        }
+        @include mixins.mobile {
+            .save-modal-list {
+                padding: 0;
+                padding-bottom: var(--gap);
+            }
+            .save-modal-newlist {
+                padding: 0;
+            }
+        }
+        &.is-page-list {
+            .modal-card-actions {
+                display: grid;
+                > * {
+                    margin: 0;
+                }
+            }
+        }
+    }
+    .edit-list-modal {
+        .edit-list-modal-form {
+            padding: 0;
+        }
+    }
+    .edit-list-modal-form {
+        display: flex;
+        flex-direction: column;
+        padding: var(--card-padding);
+        padding-bottom: 0;
+        > * {
+            margin-bottom: var(--gap);
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+        @include mixins.mobile {
+            padding: 0;
+            padding-bottom: var(--gap);
         }
     }
 }

--- a/ui/src/scss/_home.scss
+++ b/ui/src/scss/_home.scss
@@ -718,8 +718,8 @@ a {
             list-style: none;
             display: flex;
             flex-direction: column;
-            align-items: center;
-            text-align: center;
+            // align-items: center;
+            // text-align: center;
             li {
                 margin-bottom: 6px;
                 &:last-child {

--- a/ui/src/scss/_list.scss
+++ b/ui/src/scss/_list.scss
@@ -1,0 +1,196 @@
+@use 'mixins';
+
+.page-lists {
+    @include mixins.mobile {
+        padding-left: var(--gap);
+        padding-right: var(--gap);
+    }
+    > main {
+        grid-column: 2 / 4;
+        display: flex;
+        flex-direction: column;
+        @include mixins.mobile {
+            grid-column: 1 / 2;
+        }
+    }
+    .lists-head {
+        margin-bottom: 2rem;
+        h1 {
+            font-size: var(--fs-2xl);
+            font-weight: 600;
+            a {
+                color: var(--color-link);
+                font-weight: inherit;
+                &:visited {
+                    color: var(--color-link);
+                }
+            }
+        }
+    }
+    .lists-main {
+        display: flex;
+        flex-direction: column;
+        .lists-main-head {
+            display: flex;
+            justify-content: space-between;
+            .left {
+                display: flex;
+                > * {
+                    margin-right: var(--gap);
+                    &:last-child {
+                        margin-right: 0;
+                    }
+                }
+            }
+        }
+        .lists-main-main {
+            margin-top: var(--gap);
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            grid-gap: var(--gap);
+            @include mixins.mobile {
+                grid-template-columns: 1fr;
+            }
+        }
+    }
+    .list-thumb {
+        width: 300px;
+        display: flex;
+        flex-direction: column;
+        padding: calc(var(--gap) / 2);
+        border-radius: var(--border-radius);
+        cursor: pointer;
+        color: inherit; // Because of the a tag.
+        text-decoration: inherit; // Because of the a tag.
+        &:hover {
+            background: rgba(var(--base-fg), 0.05);
+        }
+        .list-thumb-top {
+            .list-thumb-image {
+                height: 200px;
+                border-radius: var(--border-radius);
+                img {
+                    border-radius: var(--border-radius);
+                }
+                &.is-default {
+                    background: rgba(var(--base-fg), 0.05);
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
+                    border: 2px rgba(var(--base-fg), 0.1) solid;
+                    svg {
+                        --size: 65px;
+                        width: var(--size);
+                        height: var(--size);
+                        opacity: 0.7;
+                    }
+                }
+            }
+        }
+        .list-thumb-bottom {
+            margin-top: 5px;
+            display: grid;
+            grid-template-columns: 1fr max-content;
+            grid-gap: var(--gap);
+            .list-thumb-name {
+                span.is-name {
+                    font-weight: 600;
+                }
+                span.is-age {
+                    margin-left: 5px;
+                    opacity: 0.75;
+                    font-size: var(--fs-xs);
+                }
+            }
+            .list-thumb-count {
+                justify-self: end;
+            }
+        }
+    }
+}
+
+.page-list {
+    padding-top: 0;
+    .page-middle {
+        .list-head {
+            margin-left: var(--post-card-votes-margin);
+            border-top-left-radius: 0;
+            border-top-right-radius: 0;
+            display: flex;
+            flex-direction: column;
+            @include mixins.tablet {
+                margin-left: 0;
+            }
+            .list-head-main {
+                display: flex;
+                flex-direction: column;
+                > * {
+                    margin-bottom: var(--gap);
+                }
+                .list-head-top {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: baseline;
+                    margin-bottom: 0;
+                }
+            }
+            .list-head-name {
+                font-size: var(--fs-2xl);
+            }
+            .list-head-user {
+                align-self: flex-start;
+                font-size: var(--fs-s);
+            }
+            .list-head-actions {
+                display: flex;
+                > * {
+                    margin-right: var(--gap);
+                    &:last-child {
+                        margin-right: 0;
+                    }
+                }
+            }
+        }
+    }
+    .list-summary {
+        .card-list-item {
+            display: flex;
+            align-items: center;
+            svg {
+                width: var(--icon-size);
+                height: var(--icon-size);
+            }
+            div {
+                margin-left: var(--gap);
+            }
+        }
+    }
+    .lists-feed {
+        margin-top: var(--gap);
+        .comment {
+            margin-left: var(--post-card-votes-margin);
+            @include mixins.tablet {
+                margin-left: 0;
+            }
+        }
+    }
+    .sidebar-right {
+        > * {
+            margin-bottom: var(--gap);
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+}
+
+.edit-list-modal {
+    .modal-card-content {
+        > * {
+            margin-bottom: var(--gap);
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+}

--- a/ui/src/scss/_static.scss
+++ b/ui/src/scss/_static.scss
@@ -1,9 +1,5 @@
 @use 'mixins';
 
-body.is-static-page {
-    background: var(--color-bg);
-}
-
 .page-static {
     // max-width: 960px;
     font-size: var(--fs-xl);

--- a/ui/src/scss/_user.scss
+++ b/ui/src/scss/_user.scss
@@ -99,6 +99,9 @@
     }
     .select-bar {
         margin-left: var(--post-card-votes-margin);
+        @include mixins.tablet {
+            margin-left: 0;
+        }
     }
     .page-user-summary {
         .user-summary-item {

--- a/ui/src/scss/styles.scss
+++ b/ui/src/scss/styles.scss
@@ -12,3 +12,4 @@
 @use 'chat';
 @use 'static';
 @use 'search';
+@use 'list';

--- a/ui/src/slices/listsSlice.js
+++ b/ui/src/slices/listsSlice.js
@@ -1,0 +1,175 @@
+const initialState = {
+  ids: [], // Array of list ids.
+  usersLists: {
+    /*
+    ["username"]:  {
+      listIds: [], 
+      order: "name",  // one of: name, lastAdded.
+      filter: "all", // one of: all, public, private.
+    }
+    */
+  },
+  items: {
+    /*
+    ["list_id"]: {
+        ... list object fields,
+    }
+    */
+  },
+  nameToId: {
+    /*
+    ["username_listname"]: list_id,
+    */
+  },
+  /* The feed of each list is stored in the feedsSlice. */
+};
+
+const typeUsersListsAdded = 'lists/usersListsAdded';
+const typeListsOrderChanged = 'lists/orderChanged';
+const typeListsFilterChanged = 'lists/filterChanged';
+const typeListAdded = `lists/listAdded`;
+
+export default function listsReducer(state = initialState, action) {
+  switch (action.type) {
+    case typeUsersListsAdded: {
+      const { username, lists, order, filter } = action.payload;
+      let newItems = {};
+      const newNameToIds = {};
+      let newIds = [];
+      lists.forEach((list) => {
+        if (!state.items[list.id]) {
+          newIds.push(list.id);
+          newItems[list.id] = list;
+        }
+        const key = nameToIdKey(username, list.name);
+        if (!state.nameToId[key]) {
+          newNameToIds[key] = list.id;
+        }
+      });
+      return {
+        ...state,
+        ids: [...state.ids, ...newIds],
+        usersLists: {
+          ...state.usersLists,
+          [username]: {
+            listIds: lists.map((list) => list.id),
+            order,
+            filter,
+          },
+        },
+        items: {
+          ...state.items,
+          ...newItems,
+        },
+        nameToId: {
+          ...state.nameToId,
+          ...newNameToIds,
+        },
+      };
+    }
+    case typeListsOrderChanged: {
+      const { username, order } = action.payload;
+      return {
+        ...state,
+        usersLists: {
+          ...state.usersLists,
+          [username]: {
+            ...state.usersLists[username],
+            listIds: null,
+            order,
+          },
+        },
+      };
+    }
+    case typeListsFilterChanged: {
+      const { username, filter } = action.payload;
+      return {
+        ...state,
+        usersLists: {
+          ...state.usersLists,
+          [username]: {
+            ...state.usersLists[username],
+            listIds: null,
+            filter,
+          },
+        },
+      };
+    }
+    case typeListAdded: {
+      const { username, list } = action.payload;
+      return {
+        ...state,
+        items: {
+          ...state.items,
+          [list.id]: list,
+        },
+        nameToId: {
+          ...state.nameToId,
+          [nameToIdKey(username, list.name)]: list.id,
+        },
+      };
+    }
+    default:
+      return state;
+  }
+}
+
+const defaultOrder = 'lastAdded';
+const defaultFilter = 'all';
+
+/** Actions:  */
+
+export const usersListsAdded = (
+  username,
+  lists = [],
+  order = defaultOrder,
+  filter = defaultFilter
+) => {
+  return { type: typeUsersListsAdded, payload: { username, lists, order, filter } };
+};
+
+export const listsOrderChanged = (username, order) => {
+  return { type: typeListsOrderChanged, payload: { username, order } };
+};
+
+export const listsFilterChanged = (username, filter) => {
+  return { type: typeListsFilterChanged, payload: { username, filter } };
+};
+
+export const listAdded = (username, list) => {
+  return { type: typeListAdded, payload: { username, list } };
+};
+
+/** Selectors:  */
+
+export const selectUsersLists = (username) => (state) => {
+  if (!state.lists.usersLists[username]) {
+    return { lists: null, order: defaultOrder, filter: defaultFilter };
+  }
+  const listsState = state.lists.usersLists[username];
+  const ids = listsState.listIds;
+  let items = null;
+  if (ids) {
+    items = [];
+    ids.forEach((id) => {
+      items.push(state.lists.items[id]);
+    });
+  }
+  return {
+    lists: items,
+    order: listsState.order,
+    filter: listsState.filter,
+  };
+};
+
+export const selectList = (username, listname) => (state) => {
+  const listId = state.lists.nameToId[nameToIdKey(username, listname)];
+  if (!listId) {
+    return null;
+  }
+  return state.lists.items[listId];
+};
+
+const nameToIdKey = (username, listname) => {
+  return `${username}_${listname}`;
+};

--- a/ui/src/slices/mainSlice.js
+++ b/ui/src/slices/mainSlice.js
@@ -38,6 +38,17 @@ const initialState = {
     userMutes: [],
     communityMutes: [],
   },
+  // listsLoading: true,
+  // lists: [],
+  lists: {
+    loading: true,
+    lists: [],
+  },
+  saveToListModal: {
+    open: false,
+    toSaveItemId: null,
+    toSaveItemType: null,
+  },
 };
 
 export default function mainReducer(state = initialState, action) {
@@ -320,6 +331,37 @@ export default function mainReducer(state = initialState, action) {
         sidebarScrollY: action.payload,
       };
     }
+    case 'main/listsAdded': {
+      return {
+        ...state,
+        lists: {
+          loading: false,
+          lists: action.payload,
+        },
+      };
+    }
+    case 'main/saveToListModalOpened': {
+      const { toSaveItemId, toSaveItemType } = action.payload;
+      return {
+        ...state,
+        saveToListModal: {
+          open: true,
+          toSaveItemId: toSaveItemId,
+          toSaveItemType: toSaveItemType,
+        },
+      };
+    }
+    case 'main/saveToListModalClosed': {
+      return {
+        ...state,
+        saveToListModal: {
+          ...state.saveToListModal,
+          open: false,
+          toSaveItemId: null,
+          toSaveItemType: null,
+        },
+      };
+    }
     default:
       return state;
   }
@@ -591,4 +633,16 @@ export const selectIsCommunityMuted = (communityId) => (state) => {
 
 export const sidebarScrollYUpdated = (scrollY) => {
   return { type: 'main/sidebarScrollYUpdated', payload: scrollY };
+};
+
+export const listsAdded = (lists) => {
+  return { type: 'main/listsAdded', payload: lists };
+};
+
+export const saveToListModalOpened = (toSaveItemId, toSaveItemType) => {
+  return { type: 'main/saveToListModalOpened', payload: { toSaveItemId, toSaveItemType } };
+};
+
+export const saveToListModalClosed = () => {
+  return { type: 'main/saveToListModalClosed' };
 };


### PR DESCRIPTION
This commit introduces Lists, for bookmarking posts and comments. A bit of (incomplete) summary (refer to the PR for details):

- One DB migration added.

- 6 new API endpoints introduced.

- List items are paginated in the API and have options for sorting and filtering.

- The users lists are included in the output of `/api/_initial`.

- Two new pages are added to the front-end: all lists page and individual list page. The routes are `/@user/lists` and `/@user/lists/{listname}`.

- Delete users lists on account deletion.